### PR TITLE
immutable owner

### DIFF
--- a/src/contracts/proxies/ODProxy.sol
+++ b/src/contracts/proxies/ODProxy.sol
@@ -1,13 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {Ownable} from '@contracts/utils/Ownable.sol';
-
-contract ODProxy is Ownable {
+contract ODProxy {
   error TargetAddressRequired();
   error TargetCallFailed(bytes _response);
+  error OnlyOwner();
 
-  constructor(address _owner) Ownable(_owner) {}
+  address public immutable OWNER;
+
+  constructor(address _owner) {
+    OWNER = _owner;
+  }
+
+  /**
+   * @notice Checks whether msg.sender can call an owned function
+   */
+  modifier onlyOwner() {
+    if (msg.sender != OWNER) revert OnlyOwner();
+    _;
+  }
 
   function execute(address _target, bytes memory _data) external payable onlyOwner returns (bytes memory _response) {
     if (_target == address(0)) revert TargetAddressRequired();

--- a/src/contracts/proxies/Vault721.sol
+++ b/src/contracts/proxies/Vault721.sol
@@ -12,7 +12,6 @@ contract Vault721 is ERC721('OpenDollarVault', 'ODV') {
   mapping(address proxy => address user) internal _proxyRegistry;
   mapping(address user => address proxy) internal _userRegistry;
 
-  event Mint(address _proxy, uint256 _safeId);
   event CreateProxy(address indexed _user, address _proxy);
 
   /**

--- a/src/contracts/proxies/Vault721.sol
+++ b/src/contracts/proxies/Vault721.sol
@@ -74,7 +74,7 @@ contract Vault721 is ERC721('OpenDollarVault', 'ODV') {
    * @dev check that proxy does not exist OR that the user does not own proxy
    */
   function _isNotProxy(address _user) internal view returns (bool) {
-    return _userRegistry[_user] == address(0) || ODProxy(_userRegistry[_user]).owner() != _user;
+    return _userRegistry[_user] == address(0) || ODProxy(_userRegistry[_user]).OWNER() != _user;
   }
 
   /**

--- a/src/contracts/proxies/Vault721.sol
+++ b/src/contracts/proxies/Vault721.sol
@@ -29,7 +29,7 @@ contract Vault721 is ERC721('OpenDollarVault', 'ODV') {
     safeManager = msg.sender;
   }
 
-  function getProxy(address _user) external returns (address _proxy) {
+  function getProxy(address _user) external view returns (address _proxy) {
     _proxy = _userRegistry[_user];
   }
 


### PR DESCRIPTION
`setOwner` from Ownable is not used anywhere in protocol. There is another `setOwner` function from an Auth contract, which is used in testing.

solves #76 
solves #71 
solves #24 
solves #23 