### PR TITLE
Script to prep addresses for SDK

### DIFF
--- a/tasks/.gitignore
+++ b/tasks/.gitignore
@@ -1,0 +1,2 @@
+output.js
+*.sol

--- a/tasks/prepareForSdk.js
+++ b/tasks/prepareForSdk.js
@@ -1,0 +1,93 @@
+const fs = require("fs");
+const path = require("path");
+
+const filePath = path.join(__dirname, "../src/script/GoerliContracts.s.sol");
+
+fs.readFile(filePath, "utf8", (err, data) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  const cleanedString = data
+    .replace(/address public /g, "")
+    .replace(/;/g, "")
+    .replace(/ /g, "");
+
+  // Split the string into lines
+  const lines = cleanedString.split("\n");
+
+  // Create an empty object to store the converted values
+  const parsed = {};
+
+  // Iterate over each line and populate the output object
+  lines.forEach((line) => {
+    const [key, value] = line.split("=");
+    parsed[key.trim()] = value?.trim();
+  });
+
+  const final = {
+    MULTICALL: "0xcA11bde05977b3631167028862bE2a173976CA11",
+    // VERIFY!!!
+    ETH: "0xEe01c0CD76354C383B8c7B4e65EA88D00B06f36f",
+    GEB_SYSTEM_COIN: parsed.systemCoinAddr,
+    GEB_PROTOCOL_TOKEN: parsed.protocolTokenAddr,
+    GEB_SAFE_ENGINE: parsed.safeEngineAddr,
+    GEB_ORACLE_RELAYER: parsed.oracleRelayerAddr,
+    GEB_SURPLUS_AUCTION_HOUSE: parsed.surplusAuctionHouseAddr,
+    GEB_DEBT_AUCTION_HOUSE: parsed.debtAuctionHouseAddr,
+    GEB_COLLATERAL_AUCTION_HOUSE_FACTORY:
+      parsed.collateralAuctionHouseFactoryAddr,
+    GEB_ACCOUNTING_ENGINE: parsed.accountingEngineAddr,
+    GEB_LIQUIDATION_ENGINE: parsed.liquidationEngineAddr,
+    GEB_COIN_JOIN: parsed.coinJoinAddr,
+    GEB_COLLATERAL_JOIN_FACTORY: parsed.collateralJoinFactoryAddr,
+    GEB_TAX_COLLECTOR: parsed.taxCollectorAddr,
+    GEB_STABILITY_FEE_TREASURY: parsed.stabilityFeeTreasuryAddr,
+    GEB_GLOBAL_SETTLEMENT: parsed.globalSettlementAddr,
+    GEB_POST_SETTLEMENT_SURPLUS_AUCTION_HOUSE:
+      parsed.postSettlementSurplusAuctionHouseAddr,
+    GEB_POST_SETTLEMENT_SURPLUS_AUCTIONEER:
+      parsed.settlementSurplusAuctioneerAddr,
+    GEB_RRFM_SETTER: parsed.PIDRateSetterAddr,
+    GEB_RRFM_CALCULATOR: parsed.PIDControllerAddr,
+    SAFE_MANAGER: parsed.odSafeManagerAddr,
+    GEB_GLOBAL_SETTLEMENT: parsed.globalSettlementAddr,
+    PROXY_FACTORY: parsed.vault721Addr,
+    PROXY_BASIC_ACTIONS: parsed.basicActionsAddr,
+    PROXY_REGISTRY: parsed.vault721Addr,
+    PROXY_DEBT_AUCTION_ACTIONS: parsed.debtBidActionsAddr,
+    PROXY_SURPLUS_AUCTION_ACTIONS: parsed.surplusBidActionsAddr,
+    PROXY_COLLATERAL_AUCTION_ACTIONS: parsed.collateralBidActionsAddr,
+    PROXY_POST_SETTLEMENT_SURPLUS_AUCTION_ACTIONS:
+      parsed.postSettlementSurplusBidActionsAddr,
+    PROXY_GLOBAL_SETTLEMENT_ACTIONS: parsed.globalSettlementActionsAddr,
+    PROXY_REWARDED_ACTIONS: parsed.rewardedActionsAddr,
+    JOB_ACCOUNTING: parsed.accountingJobAddr,
+    JOB_LIQUIDATION: parsed.liquidationJobAddr,
+    JOB_ORACLES: parsed.oracleJobAddr,
+  };
+
+  const validate = (obj) => {
+    const missing = Object.values(obj).reduce((acc, curr, i) => {
+      if (!curr) {
+        acc.push(Object.keys(obj)[i]);
+      }
+      return acc;
+    }, []);
+    if (missing.length) throw `Missing values: ${missing.join(", ")}`;
+  };
+
+  validate(final);
+
+  const outputPath = path.join(__dirname, "./output.js");
+  const content = `export default ${JSON.stringify(final, null, 2)}`;
+  fs.writeFile(outputPath, content, (err) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+
+    console.log("JSON object written to file successfully!");
+  });
+});


### PR DESCRIPTION
This script enables a repeatable method for converting the deployment addresses into the format expected by the SDK, to reduce human error. 

```sol
// SPDX-License-Identifier: GPL-3.0
pragma solidity 0.8.19;

abstract contract GoerliContracts {
  address public chainlinkRelayerFactoryAddr = 0xf67824c9dD65425600639Bb1F18c08368A147c69;
  address public uniV3RelayerFactoryAddr = 0xC2d2F3fcA75D05387DB01214D03B6d1EC5F22e44;
  address public denominatedOracleFactoryAddr = 0x290Fdb5878Ac39C888aB0ebdF07c6d5929F6bf65;
  address public delayedOracleFactoryAddr = 0x76E0D3f31B633dBeDd07ec21Dd2Af389E6A6E6e0;
```

Becomes

```js
export default {
        GEB_SURPLUS_AUCTION_HOUSE: '0x97Ba91F8161c67eC0f5600f96Aa6B78eEcA83E2f',
        GEB_DEBT_AUCTION_HOUSE: '0x73098945f3e73caf01909C957A6bd65ED910F637',
        GEB_ACCOUNTING_ENGINE: '0xbeed3E8a9F70A91C5bc5f955B71317C456366CFA',
  //...
  ```