### PR TITLE
Issue #169: Forge docs formatting

### DIFF
--- a/docs/src/theme/css/base.css
+++ b/docs/src/theme/css/base.css
@@ -1,3 +1,18 @@
+@media screen and (max-width: 1280px) {
+  .sidebar {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  .next {
+    display: none;
+  }
+  .previous {
+    display: none;
+  }
+}
+
 /*
  * Side bar
  */

--- a/docs/src/theme/js/base.js
+++ b/docs/src/theme/js/base.js
@@ -10,4 +10,14 @@
       elm.nextElementSibling.click(); // click on toggle
     });
   });
+  document.addEventListener('DOMContentLoaded', function () {
+    const sidebarToggle = document.getElementById('sidebar-toggle');
+    const sidebar = document.getElementById('sidebar');
+
+    if (sidebarToggle && sidebar) {
+      sidebarToggle.addEventListener('click', function () {
+        sidebar.classList.toggle('hidden')
+      });
+    }
+  });
 })();


### PR DESCRIPTION
Closes #169 

## Description
- Hamburger menu can now toggle showing/hiding the sidebar on desktop (on mobile there's some forge css preventing the hamburger menu from opening the sidebar but I think for now this is ok because the table of contents is on the second page)
- left sidebar goes away on small screen sizes to prevent it from covering the content
- mobile nav buttons (called .previous and .next) will disappear on desktop because they were covering up the desktop sidebar before

## Screenshots

https://github.com/open-dollar/od-contracts/assets/47253537/11da97dc-fe43-4a3b-8a05-9c890106a4e0

