### PR TITLE
ODSafeManager handlerExists added, draft tests added in NFT.t.sol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,6 @@ ARB_SEPOLIA_DEPLOYER_PK=0x
 
 ARB_ETHERSCAN_API_KEY=
 
-// run `anvil` and copy a private key from anvil terminal
+# run `anvil` and copy a private key from anvil terminal
 ANVIL_ONE=
 ANVIL_RPC=http://127.0.0.1:8545

--- a/src/contracts/proxies/ODSafeManager.sol
+++ b/src/contracts/proxies/ODSafeManager.sol
@@ -172,7 +172,7 @@ contract ODSafeManager is IODSafeManager {
   /// @inheritdoc IODSafeManager
   function transferCollateral(uint256 _safe, address _dst, uint256 _wad) external safeAllowed(_safe) {
     SAFEData memory _sData = _safeData[_safe];
-    if (!handlerExists[_sData.safeHandler]) revert HandlerDoesNotExist();
+    if (!handlerExists[_dst]) revert HandlerDoesNotExist();
 
     ISAFEEngine(safeEngine).transferCollateral(_sData.collateralType, _sData.safeHandler, _dst, _wad);
     emit TransferCollateral(msg.sender, _safe, _dst, _wad);

--- a/src/contracts/proxies/ODSafeManager.sol
+++ b/src/contracts/proxies/ODSafeManager.sol
@@ -39,6 +39,8 @@ contract ODSafeManager is IODSafeManager {
   mapping(address _owner => mapping(uint256 _safeId => mapping(address _caller => uint256 _ok))) public safeCan;
   /// @inheritdoc IODSafeManager
   mapping(address _safeHandler => mapping(address _caller => uint256 _ok)) public handlerCan;
+  /// @inheritdoc IODSafeManager
+  mapping(address _safeHandler => bool _exists) public handlerExists;
 
   // --- Modifiers ---
 
@@ -122,6 +124,9 @@ contract ODSafeManager is IODSafeManager {
     address _safeHandler = address(new SAFEHandler(safeEngine));
 
     _safeData[_safeId] = SAFEData({owner: _usr, safeHandler: _safeHandler, collateralType: _cType});
+    
+    // Save the address of the safeHandler
+    handlerExists[_safeHandler] = true;
 
     _usrSafes[_usr].add(_safeId);
     _usrSafesPerCollat[_usr][_cType].add(_safeId);
@@ -167,6 +172,8 @@ contract ODSafeManager is IODSafeManager {
   /// @inheritdoc IODSafeManager
   function transferCollateral(uint256 _safe, address _dst, uint256 _wad) external safeAllowed(_safe) {
     SAFEData memory _sData = _safeData[_safe];
+    if (!handlerExists[_sData.safeHandler]) revert HandlerDoesNotExist();
+
     ISAFEEngine(safeEngine).transferCollateral(_sData.collateralType, _sData.safeHandler, _dst, _wad);
     emit TransferCollateral(msg.sender, _safe, _dst, _wad);
   }

--- a/src/contracts/proxies/ODSafeManager.sol
+++ b/src/contracts/proxies/ODSafeManager.sol
@@ -124,7 +124,7 @@ contract ODSafeManager is IODSafeManager {
     address _safeHandler = address(new SAFEHandler(safeEngine));
 
     _safeData[_safeId] = SAFEData({owner: _usr, safeHandler: _safeHandler, collateralType: _cType});
-    
+
     // Save the address of the safeHandler
     handlerExists[_safeHandler] = true;
 

--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -43,6 +43,8 @@ interface IODSafeManager {
   error AlreadySafeOwner();
   /// @notice Throws when trying to move a safe to another one with different collateral type
   error CollateralTypesMismatch();
+  /// @notice Throws when trying to transfer collateral to an address that isn't a SAFEHandler
+  error HandlerDoesNotExist();
 
   // --- Structs ---
 
@@ -65,6 +67,9 @@ interface IODSafeManager {
 
   /// @notice Mapping of handler to a caller permissions
   function handlerCan(address _safeHandler, address _caller) external view returns (uint256 _ok);
+
+  /// @notice Mapping of handler to whether it exists 
+  function handlerExists(address _safeHandler) external view returns (bool _exists);
 
   // --- Getters ---
 

--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -68,7 +68,7 @@ interface IODSafeManager {
   /// @notice Mapping of handler to a caller permissions
   function handlerCan(address _safeHandler, address _caller) external view returns (uint256 _ok);
 
-  /// @notice Mapping of handler to whether it exists 
+  /// @notice Mapping of handler to whether it exists
   function handlerExists(address _safeHandler) external view returns (bool _exists);
 
   // --- Getters ---

--- a/test/nft/anvil/AnvilFork.t.sol
+++ b/test/nft/anvil/AnvilFork.t.sol
@@ -83,7 +83,7 @@ contract AnvilFork is AnvilDeployment, Test {
     labelVars();
     mintCollateralAndOpenSafes();
 
-    // debtCeiling = setDebtCeiling();
+    debtCeiling = setDebtCeiling();
 
     newCAddress = address(new MintableVoteERC20('NewCoin', 'NC', 18));
   }

--- a/test/nft/anvil/NFT.t.sol
+++ b/test/nft/anvil/NFT.t.sol
@@ -183,7 +183,7 @@ contract NFTAnvil is AnvilFork {
     );
 
     vm.startPrank(aliceProxy);
-    // TODO: when we deposit collateral, it is locked, how do we move it from locked to tokenCollateral so
+    // @note when we deposit collateral, it is locked, how do we move it from locked to tokenCollateral so
     // we can transfer it? this will fail if we try to transfer non-zero value
     safeManager.transferCollateral(aliceVaultId, bobSafeHandler, 0);
     vm.stopPrank();

--- a/test/nft/anvil/NFT.t.sol
+++ b/test/nft/anvil/NFT.t.sol
@@ -182,7 +182,7 @@ contract NFTAnvil is AnvilFork {
     uint256 bobSafeId = safeManager.openSAFE(cTypes[cTypeIndex], alice);
     vm.stopPrank();
 
-    SAFEData memory bobSafeData = safeManager.safeData(bobSafeId);
+    IODSafeManager.SAFEData memory bobSafeData = safeManager.safeData(bobSafeId);
 
     vm.startPrank(alice);
     safeManager.transferCollateral(aliceSafeId, bobSafeData.safeHandler, 0);

--- a/test/nft/anvil/NFT.t.sol
+++ b/test/nft/anvil/NFT.t.sol
@@ -168,7 +168,7 @@ contract NFTAnvil is AnvilFork {
     address alice = users[0];
     address aliceProxy = proxies[0]; // alice's proxy
     bytes32 cType = cTypes[cTypeIndex];
-    uint256 aliceVaultId = _helperDepositCollateralAndGenerateDebt(alice, aliceProxy, cType, 100, 0);
+    uint256 aliceVaultId = _helperDepositCollateralAndGenerateDebt(alice, aliceProxy, cType, collateral, 0);
 
     address bob = users[1];
     address bobProxy = proxies[1]; // bob's proxy
@@ -183,7 +183,7 @@ contract NFTAnvil is AnvilFork {
     );
 
     vm.startPrank(aliceProxy);
-    // @note when we deposit collateral, it is locked, how do we move it from locked to tokenCollateral so
+    // @note TODO when we deposit collateral, it is locked, how do we move it from locked to tokenCollateral so
     // we can transfer it? this will fail if we try to transfer non-zero value
     safeManager.transferCollateral(aliceVaultId, bobSafeHandler, 0);
     vm.stopPrank();

--- a/test/nft/anvil/NFT.t.sol
+++ b/test/nft/anvil/NFT.t.sol
@@ -183,13 +183,13 @@ contract NFTAnvil is AnvilFork {
     );
 
     vm.startPrank(aliceProxy);
-    // TODO: when we deposit collateral, it is locked, how do we move it from locked to tokenCollateral so 
+    // TODO: when we deposit collateral, it is locked, how do we move it from locked to tokenCollateral so
     // we can transfer it? this will fail if we try to transfer non-zero value
     safeManager.transferCollateral(aliceVaultId, bobSafeHandler, 0);
     vm.stopPrank();
     assertEq(
       safeEngine.tokenCollateral(cType, bobSafeHandler),
-      0, 
+      0,
       'test_transferCollateralToSafeHandler: collateral is not equal'
     );
   }


### PR DESCRIPTION
### Outcome of Changes
- transferCollateral to non safeHandler address will revert with `HandlerDoesNotExist()` custom error
- transferCollateral to safeHandler address will work as expected
- `test_depositCollateral_generateDebt` and `test_generateDebt` tests fixed

### ODSafeManager.sol
- [x] New mapping in ODSafeManager.sol: mapping(address _safeHandler => bool _exists) public handlerExists;
- [x] New view function in IODSafeManager.sol: function handlerExists(address _safeHandler) external view returns (bool _exists);
### Test Cases
- [x] ODSafeManager.transferCollateral reverts if transferring to non-safeHandler address
- [x] ODSafeManager.transferCollateral passes if transferring to safeHandler address

closes https://github.com/open-dollar/od-contracts/issues/215