### PR TITLE
Fix generated debt mismatch

### DIFF
--- a/src/contracts/proxies/actions/BasicActions.sol
+++ b/src/contracts/proxies/actions/BasicActions.sol
@@ -9,6 +9,7 @@ import {ICoinJoin} from '@interfaces/utils/ICoinJoin.sol';
 import {ITaxCollector} from '@interfaces/ITaxCollector.sol';
 import {ICollateralJoin} from '@interfaces/utils/ICollateralJoin.sol';
 import {IERC20Metadata} from '@openzeppelin/token/ERC20/extensions/IERC20Metadata.sol';
+import {SafeCast} from '@openzeppelin/utils/math/SafeCast.sol';
 import {IBasicActions} from '@interfaces/proxies/actions/IBasicActions.sol';
 
 import {Math, WAD, RAY, RAD} from '@libraries/Math.sol';
@@ -21,6 +22,7 @@ import {CommonActions} from '@contracts/proxies/actions/CommonActions.sol';
  */
 contract BasicActions is CommonActions, IBasicActions {
   using Math for uint256;
+  using SafeCast for int256;
 
   // --- Internal functions ---
 
@@ -102,16 +104,14 @@ contract BasicActions is CommonActions, IBasicActions {
     ODSafeManager.SAFEData memory _safeInfo = ODSafeManager(_manager).safeData(_safeId);
     ITaxCollector(_taxCollector).taxSingle(_safeInfo.collateralType);
 
+    int256 deltaDebt = _getGeneratedDeltaDebt(_safeEngine, _safeInfo.collateralType, _safeInfo.safeHandler, _deltaWad);
+
     // Generates debt in the SAFE
-    _modifySAFECollateralization(
-      _manager,
-      _safeId,
-      0,
-      _getGeneratedDeltaDebt(_safeEngine, _safeInfo.collateralType, _safeInfo.safeHandler, _deltaWad)
-    );
+    _modifySAFECollateralization(_manager, _safeId, 0, deltaDebt);
 
     // Moves the COIN amount to user's address
-    _collectAndExitCoins(_manager, _coinJoin, _safeId, _deltaWad);
+    // deltaDebt should always be positive, but we use SafeCast as an extra guard
+    _collectAndExitCoins(_manager, _coinJoin, _safeId, deltaDebt.toUint256());
   }
 
   /**
@@ -183,16 +183,14 @@ contract BasicActions is CommonActions, IBasicActions {
     // Takes token amount from user's wallet and joins into the safeEngine
     _joinCollateral(_collateralJoin, _safeInfo.safeHandler, _collateralAmount);
 
+    int256 deltaDebt = _getGeneratedDeltaDebt(_safeEngine, _safeInfo.collateralType, _safeInfo.safeHandler, _deltaWad);
+
     // Locks token amount into the SAFE and generates debt
-    _modifySAFECollateralization(
-      _manager,
-      _safeId,
-      _collateralAmount.toInt(),
-      _getGeneratedDeltaDebt(_safeEngine, _safeInfo.collateralType, _safeInfo.safeHandler, _deltaWad)
-    );
+    _modifySAFECollateralization(_manager, _safeId, _collateralAmount.toInt(), deltaDebt);
 
     // Exits and transfers COIN amount to the user's address
-    _collectAndExitCoins(_manager, _coinJoin, _safeId, _deltaWad);
+    // deltaDebt should always be positive, but we use SafeCast as an extra guard
+    _collectAndExitCoins(_manager, _coinJoin, _safeId, deltaDebt.toUint256());
   }
 
   /**


### PR DESCRIPTION
Use the value computed from: `_getGeneratedDeltaDebt` in both `_modifySAFECollateralization` and `_collectAndExitCoins` to ensure the coins sent to the user is enough to repay the debt in the same transaction.

TODO
- [ ] Find and fix 2 additional breaking tests as a result of this change
- [ ] Add an additional test where `_getGeneratedDeltaDebt` is greater/less than the raw `_deltaWad` input and try repaying debts with received coins to verify behavior before/after change.