### PR TITLE
add missing debt check

### DIFF
--- a/src/contracts/AccountingEngine.sol
+++ b/src/contracts/AccountingEngine.sol
@@ -181,6 +181,9 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
     if (_params.debtAuctionBidSize > _unqueuedUnauctionedDebt(_debtBalance)) revert AccEng_InsufficientDebt();
 
     (_coinBalance, _debtBalance) = _settleDebt(_coinBalance, _debtBalance, _coinBalance);
+
+    if (_params.debtAuctionBidSize > _unqueuedUnauctionedDebt(_debtBalance)) revert AccEng_InsufficientDebt();
+
     totalOnAuctionDebt += _params.debtAuctionBidSize;
 
     _id = debtAuctionHouse.startAuction({

--- a/src/contracts/AccountingEngine.sol
+++ b/src/contracts/AccountingEngine.sol
@@ -178,8 +178,6 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
     uint256 _coinBalance = safeEngine.coinBalance(address(this));
     uint256 _debtBalance = safeEngine.debtBalance(address(this));
 
-    if (_params.debtAuctionBidSize > _unqueuedUnauctionedDebt(_debtBalance)) revert AccEng_InsufficientDebt();
-
     (_coinBalance, _debtBalance) = _settleDebt(_coinBalance, _debtBalance, _coinBalance);
 
     if (_params.debtAuctionBidSize > _unqueuedUnauctionedDebt(_debtBalance)) revert AccEng_InsufficientDebt();


### PR DESCRIPTION
closes #240 

- we do a check after `_settleDebt` in `AccountingEngine.auctionDebt` to ensure that a debt auction cannot be created without bad debt