### PR TITLE
fix: surplus auction creation

### DIFF
--- a/src/contracts/AccountingEngine.sol
+++ b/src/contracts/AccountingEngine.sol
@@ -210,9 +210,9 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
     }
 
     // auction surplus percentage
-    if (_params.surplusTransferPercentage < ONE_HUNDRED_WAD) {
+    if (_params.surplusTransferPercentage < WAD) {
       _id = surplusAuctionHouse.startAuction({
-        _amountToSell: _params.surplusAmount.wmul(ONE_HUNDRED_WAD - _params.surplusTransferPercentage),
+        _amountToSell: _params.surplusAmount.wmul(WAD - _params.surplusTransferPercentage),
         _initialBid: 0
       });
 


### PR DESCRIPTION
Resolves #214 
* Updates the `AccountingEngine.sol` at lines [#L213](https://github.com/open-dollar/od-contracts/blob/6023a38154c87d0974a3d9fce0e47bfba7057f37/src/contracts/AccountingEngine.sol#L213) and [#L215](https://github.com/open-dollar/od-contracts/blob/6023a38154c87d0974a3d9fce0e47bfba7057f37/src/contracts/AccountingEngine.sol#L215) to use `WAD` instead of `ONE_HUNDRED_WAD` according the the submission recommendation to correct the issue of surplus auctions being created with `_amountToSell` 100x larger than it should be.