### PR TITLE
Closed #381 added totalSafes and _safeId setting

### DIFF
--- a/src/contracts/proxies/ODSafeManager.sol
+++ b/src/contracts/proxies/ODSafeManager.sol
@@ -66,6 +66,7 @@ contract ODSafeManager is IODSafeManager {
   constructor(address _safeEngine, address _vault721) {
     safeEngine = _safeEngine.assertNonNull();
     vault721 = IVault721(_vault721);
+    _safeId = vault721.totalSafes();
     vault721.initializeManager();
   }
 

--- a/src/contracts/proxies/Vault721.sol
+++ b/src/contracts/proxies/Vault721.sol
@@ -23,6 +23,8 @@ contract Vault721 is ERC721EnumerableUpgradeable {
   IODSafeManager public safeManager;
   NFTRenderer public nftRenderer;
 
+  uint256 public totalSafes;
+
   string public contractMetaData =
     '{"name": "Open Dollar Vaults","description": "Open Dollar is a DeFi lending protocol that enables borrowing against liquid staking tokens while earning staking rewards and enabling liquidity via Non-Fungible Vaults (NFVs).","image": "https://app.opendollar.com/collectionImage.png","external_link": "https://opendollar.com"}';
 
@@ -99,6 +101,8 @@ contract Vault721 is ERC721EnumerableUpgradeable {
   function mint(address _proxy, uint256 _safeId) external {
     require(msg.sender == address(safeManager), 'V721: only safeManager');
     require(_proxyRegistry[_proxy] != address(0), 'V721: non-native proxy');
+    require(totalSafes + 1 == _safeId, 'V721: invalid safeId');
+    totalSafes += 1;
     address _user = _proxyRegistry[_proxy];
     _safeMint(_user, _safeId);
   }

--- a/src/interfaces/proxies/IVault721.sol
+++ b/src/interfaces/proxies/IVault721.sol
@@ -36,4 +36,5 @@ interface IVault721 {
   // public
   function tokenURI(uint256 _safeId) external returns (string memory);
   function contractURI() external returns (string memory);
+  function totalSafes() external returns (uint256);
 }


### PR DESCRIPTION
I have implemented the following fix for issue closed #232  :

Vault721:

- Added a `totalSafes` public state variable
- Added enforcement that `_safeId` is always equal to `totalSafes + 1` during minting of a new NFV
- Increment `totalSafes` before call to `_safeMint`

ODSafeManager:

- Added a call to `Vault721.totalSafes` in the constructor
- `_safeId` is set to `totalSafes` during deployment of the Safe Manager