### PR TITLE
Closed #323 relayer decimal scaling

### DIFF
--- a/src/contracts/oracles/CamelotRelayer.sol
+++ b/src/contracts/oracles/CamelotRelayer.sol
@@ -33,7 +33,7 @@ contract CamelotRelayer is IBaseOracle, ICamelotRelayer {
   /// @inheritdoc ICamelotRelayer
   uint128 public baseAmount;
   /// @inheritdoc ICamelotRelayer
-  uint256 public multiplier;
+  int256 public multiplier;
   /// @inheritdoc ICamelotRelayer
   uint32 public quotePeriod;
 
@@ -55,7 +55,7 @@ contract CamelotRelayer is IBaseOracle, ICamelotRelayer {
     }
 
     baseAmount = uint128(10 ** IERC20Metadata(_baseToken).decimals());
-    multiplier = 18 - IERC20Metadata(_quoteToken).decimals();
+    multiplier = int256(18) - int256(uint256(IERC20Metadata(_quoteToken).decimals()));
     quotePeriod = _quotePeriod;
 
     symbol = string(abi.encodePacked(IERC20Metadata(_baseToken).symbol(), ' / ', IERC20Metadata(_quoteToken).symbol()));
@@ -101,6 +101,19 @@ contract CamelotRelayer is IBaseOracle, ICamelotRelayer {
   }
 
   function _parseResult(uint256 _quoteResult) internal view returns (uint256 _result) {
-    return _quoteResult * 10 ** multiplier;
+    if (multiplier > 0) {
+      return _quoteResult * (10 ** uint256(multiplier));
+    }
+    else if (multiplier < 0) {
+      return _quoteResult / (10 ** abs(multiplier));
+    }
+    else return _quoteResult;
   }
+
+  // @notice Return the absolute value of a signed integer as an unsigned integer
+  function abs(int256 x) internal pure returns (uint256) {
+    x >= 0 ? x : -x;
+    return uint256(x);
+  }
+
 }

--- a/src/interfaces/oracles/ICamelotRelayer.sol
+++ b/src/interfaces/oracles/ICamelotRelayer.sol
@@ -30,7 +30,7 @@ interface ICamelotRelayer is IBaseOracle {
   /**
    * @notice The multiplier used to convert the quote into an 18 decimals format
    */
-  function multiplier() external view returns (uint256 _multiplier);
+  function multiplier() external view returns (int256 _multiplier);
 
   /**
    * @notice The length of the TWAP used to consult the pool

--- a/src/interfaces/oracles/IUniV3Relayer.sol
+++ b/src/interfaces/oracles/IUniV3Relayer.sol
@@ -26,7 +26,7 @@ interface IUniV3Relayer is IBaseOracle {
   function baseAmount() external view returns (uint128 _baseAmount);
 
   /// @notice The multiplier used to convert the quote into an 18 decimals format
-  function multiplier() external view returns (uint256 _multiplier);
+  function multiplier() external view returns (int256 _multiplier);
 
   /// @notice The length of the TWAP used to consult the pool
   function quotePeriod() external view returns (uint32 _quotePeriod);


### PR DESCRIPTION
Implemented the simple fix for #233  to the exact specification you provided @pi0neerpat.  I double checked your implementation from the issue and I have previously used and tested that exact same implementation.

The one thing I added is this abs function for returning the absolute value of a negative signed integer:

```
// @notice Return the absolute value of a signed integer as an unsigned integer
  function abs(int256 x) internal pure returns (uint256) {
    x >= 0 ? x : -x;
    return uint256(x);
  }
  ```