### PR TITLE
closes #277 block front running of NFV transfer

### DIFF
--- a/src/contracts/proxies/ODProxy.sol
+++ b/src/contracts/proxies/ODProxy.sol
@@ -9,7 +9,10 @@ contract ODProxy {
   error TargetCallFailed(bytes _response);
   error OnlyOwner();
 
+  event executionTime(uint256 _lastExecution);
+
   address public immutable OWNER;
+  uint256 private _lastExecution;
 
   constructor(address _owner) {
     OWNER = _owner;
@@ -23,8 +26,16 @@ contract ODProxy {
     _;
   }
 
+  /**
+   * @notice Executes a call using logic from the target contract; in the context of this proxy
+   * @param _target The address of the target contract
+   * @param _data The data to be delegated on the target contract
+   * @return _response The response of the call
+   */
   function execute(address _target, bytes memory _data) external payable onlyOwner returns (bytes memory _response) {
     if (_target == address(0)) revert TargetAddressRequired();
+
+    _lastExecution = block.timestamp;
 
     bool _succeeded;
     (_succeeded, _response) = _target.delegatecall(_data);
@@ -32,5 +43,13 @@ contract ODProxy {
     if (!_succeeded) {
       revert TargetCallFailed(_response);
     }
+    emit executionTime(_lastExecution);
+  }
+
+  /**
+   * @notice Returns the timestamp of the last execution
+   */
+  function getLastExecution() external view returns (uint256 lastExecution) {
+    return _lastExecution;
   }
 }

--- a/src/interfaces/proxies/IODProxy.sol
+++ b/src/interfaces/proxies/IODProxy.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.19;
+
+// Open Dollar
+// Version 1.5.8
+
+interface IODProxy {
+  function getLastExecution() external view returns (uint256 lastExecution);
+}


### PR DESCRIPTION
Closed #277 

Modified ODProxy and Vault721 in order to block any NFV transfer within a set `executionDelay` time.

This is the simple, inefficient but highly composable solution to the front-running SAFE modification during NFV marketplace trading.