### PR TITLE
silenced compiler warnings

### DIFF
--- a/src/contracts/for-test/MintableVoteERC20.sol
+++ b/src/contracts/for-test/MintableVoteERC20.sol
@@ -19,8 +19,8 @@ contract MintableVoteERC20 is MintableERC20, ERC20Burnable, ERC20Votes {
     uint8 __decimals
   ) MintableERC20(_name, _symbol, __decimals) ERC20Permit(_name) {}
 
-  function decimals() public view virtual override(ERC20, MintableERC20) returns (uint8 __decimals) {
-    super.decimals();
+  function decimals() public view virtual override(ERC20, MintableERC20) returns (uint8) {
+    return _decimals;
   }
 
   function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {

--- a/src/contracts/proxies/NFTRenderer.sol
+++ b/src/contracts/proxies/NFTRenderer.sol
@@ -398,7 +398,7 @@ contract NFTRenderer {
    * @dev converts timestamp to human readable date and time format
    */
   function _formatDateTime(uint256 timestamp) internal pure returns (string memory) {
-    (uint256 year, uint256 month, uint256 day, uint256 hour, uint256 minute, uint256 second) =
+    (uint256 year, uint256 month, uint256 day, uint256 hour, uint256 minute, ) =
       timestamp.timestampToDateTime();
 
     string memory _month;

--- a/src/contracts/proxies/Vault721.sol
+++ b/src/contracts/proxies/Vault721.sol
@@ -190,7 +190,7 @@ contract Vault721 is ERC721EnumerableUpgradeable {
    * @dev _transfer calls `transferSAFEOwnership` on SafeManager
    * enforces that ODProxy exists for transfer or it deploys a new ODProxy for receiver of vault/nft
    */
-  function _afterTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal override {
+  function _afterTokenTransfer(address from, address to, uint256 firstTokenId, uint256) internal override {
     require(to != address(0), 'V721: no burn');
     if (from != address(0)) {
       address payable proxy;

--- a/src/contracts/proxies/actions/BasicActions.sol
+++ b/src/contracts/proxies/actions/BasicActions.sol
@@ -186,12 +186,7 @@ contract BasicActions is CommonActions, IBasicActions {
     int256 deltaDebt = _getGeneratedDeltaDebt(_safeEngine, _safeInfo.collateralType, _safeInfo.safeHandler, _deltaWad);
 
     // Locks token amount into the SAFE and generates debt
-    _modifySAFECollateralization(
-      _manager,
-      _safeId,
-      _collateralAmount.toInt(),
-      deltaDebt
-    );
+    _modifySAFECollateralization(_manager, _safeId, _collateralAmount.toInt(), deltaDebt);
 
     // Exits and transfers COIN amount to the user's address
     // deltaDebt should always be positive, but we use SafeCast as an extra guard
@@ -231,12 +226,12 @@ contract BasicActions is CommonActions, IBasicActions {
   }
 
   /// @inheritdoc IBasicActions
-  function allowSAFE(address _manager, uint256 _safeId, address _usr, uint256 _ok) external delegateCall {
+  function allowSAFE(address _manager, uint256 _safeId, address _usr, bool _ok) external delegateCall {
     ODSafeManager(_manager).allowSAFE(_safeId, _usr, _ok);
   }
 
   /// @inheritdoc IBasicActions
-  function allowHandler(address _manager, address _usr, uint256 _ok) external delegateCall {
+  function allowHandler(address _manager, address _usr, bool _ok) external delegateCall {
     ODSafeManager(_manager).allowHandler(_usr, _ok);
   }
 

--- a/src/contracts/utils/Modifiable.sol
+++ b/src/contracts/utils/Modifiable.sol
@@ -30,8 +30,8 @@ abstract contract Modifiable is IModifiable, Authorizable {
     bytes32 _param,
     bytes memory _data
   ) external isAuthorized validCParams(_cType) {
-    _modifyParameters(_cType, _param, _data);
     emit ModifyParameters(_param, _cType, _data);
+    _modifyParameters(_cType, _param, _data);
   }
 
   // --- Internal virtual methods ---

--- a/src/interfaces/proxies/actions/IBasicActions.sol
+++ b/src/interfaces/proxies/actions/IBasicActions.sol
@@ -21,13 +21,13 @@ interface IBasicActions is ICommonActions {
    * @param  _usr Address of the user to allow/disallow
    * @param  _ok Boolean state to allow/disallow
    */
-  function allowSAFE(address _manager, uint256 _safe, address _usr, uint256 _ok) external;
+  function allowSAFE(address _manager, uint256 _safe, address _usr, bool _ok) external;
   /**
    * @notice Allow/disallow a handler address to manage the safe
    * @param  _usr Address of the user to allow/disallow
    * @param  _ok Boolean state to allow/disallow
    */
-  function allowHandler(address _manager, address _usr, uint256 _ok) external;
+  function allowHandler(address _manager, address _usr, bool _ok) external;
   /**
    * @notice Modify a SAFE's collateralization ratio while keeping the generated COIN or collateral freed in the safe handler address
    * @param  _safe Id of the SAFE

--- a/test/testlocal/nft/anvil/AnvilFork.t.sol
+++ b/test/testlocal/nft/anvil/AnvilFork.t.sol
@@ -149,13 +149,13 @@ contract AnvilFork is AnvilDeployment, Test {
     _safeId = abi.decode(safeData, (uint256));
   }
 
-  function allowSafe(address _proxy, uint256 _safeId, address _user, uint256 _ok) public {
+  function allowSafe(address _proxy, uint256 _safeId, address _user, bool _ok) public {
     bytes memory payload =
       abi.encodeWithSelector(basicActions.allowSAFE.selector, address(safeManager), _safeId, _user, _ok);
     ODProxy(_proxy).execute(address(basicActions), payload);
   }
 
-  function allowHandler(address _proxy, address _user, uint256 _ok) public {
+  function allowHandler(address _proxy, address _user, bool _ok) public {
     bytes memory payload = abi.encodeWithSelector(basicActions.allowHandler.selector, address(safeManager), _user, _ok);
     ODProxy(_proxy).execute(address(basicActions), payload);
   }

--- a/test/testlocal/nft/anvil/NFT.t.sol
+++ b/test/testlocal/nft/anvil/NFT.t.sol
@@ -233,8 +233,8 @@ contract NFTAnvil is AnvilFork {
    * test locking collateral
    */
 
-  function test_allowSAFE(uint256 cTypeIndex, uint8 ok) public {
-    vm.assume(ok < 2);
+  function test_allowSAFE(uint256 cTypeIndex, bool ok) public {
+    // vm.assume(ok < 2);
     cTypeIndex = bound(cTypeIndex, 1, cTypes.length - 1); // range: WSTETH, CBETH, RETH, MAGIC
     uint256 i = 0;
     address proxy = proxies[i];
@@ -249,8 +249,8 @@ contract NFTAnvil is AnvilFork {
     assertEq(safeManager.safeCan(sData.owner, vaultId, users[i]), ok, 'test_allowSAFE: safeCan not set correctly');
   }
 
-  function test_allowHandler(uint256 cTypeIndex, uint8 ok) public {
-    vm.assume(ok < 2);
+  function test_allowHandler(uint256 cTypeIndex, bool ok) public {
+    // vm.assume(ok < 2);
     cTypeIndex = bound(cTypeIndex, 1, cTypes.length - 1); // range: WSTETH, CBETH, RETH, MAGIC
     uint256 i = 0;
     address proxy = proxies[i];

--- a/test/testnet/single/AccountingEngine.t.sol
+++ b/test/testnet/single/AccountingEngine.t.sol
@@ -89,10 +89,10 @@ contract SingleAccountingEngineTest is DSTest {
     (ok,) = address(debtAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy, bid));
   }
 
-  function try_call(address addr, bytes calldata data) external returns (bool) {
+  function try_call(address addr, bytes calldata data) external returns (bool ok) {
     bytes memory _data = data;
     assembly {
-      let ok := call(gas(), addr, 0, add(_data, 0x20), mload(_data), 0, 0)
+      ok := call(gas(), addr, 0, add(_data, 0x20), mload(_data), 0, 0)
       let free := mload(0x40)
       mstore(free, ok)
       mstore(0x40, add(free, 32))
@@ -100,26 +100,26 @@ contract SingleAccountingEngineTest is DSTest {
     }
   }
 
-  function can_auctionSurplus() public returns (bool) {
+  function can_auctionSurplus() public returns (bool ok) {
     string memory sig = 'auctionSurplus()';
     bytes memory data = abi.encodeWithSignature(sig);
+    bytes memory success;
 
     bytes memory can_call = abi.encodeWithSignature('try_call(address,bytes)', accountingEngine, data);
-    (bool ok, bytes memory success) = address(this).call(can_call);
+    (ok, success) = address(this).call(can_call);
 
     ok = abi.decode(success, (bool));
-    if (ok) return true;
   }
 
-  function can_auction_debt() public returns (bool) {
+  function can_auction_debt() public returns (bool ok) {
     string memory sig = 'auctionDebt()';
     bytes memory data = abi.encodeWithSignature(sig);
+    bytes memory success;
 
     bytes memory can_call = abi.encodeWithSignature('try_call(address,bytes)', accountingEngine, data);
-    (bool ok, bytes memory success) = address(this).call(can_call);
+    (ok, success) = address(this).call(can_call);
 
     ok = abi.decode(success, (bool));
-    if (ok) return true;
   }
 
   uint256 constant ONE = 10 ** 27;

--- a/test/testnet/single/SAFEEngine.t.sol
+++ b/test/testnet/single/SAFEEngine.t.sol
@@ -46,10 +46,10 @@ contract Usr {
     safeEngine = _safeEngine;
   }
 
-  function try_call(address addr, bytes calldata data) external returns (bool) {
+  function try_call(address addr, bytes calldata data) external returns (bool ok) {
     bytes memory _data = data;
     assembly {
-      let ok := call(gas(), addr, 0, add(_data, 0x20), mload(_data), 0, 0)
+      ok := call(gas(), addr, 0, add(_data, 0x20), mload(_data), 0, 0)
       let free := mload(0x40)
       mstore(free, ok)
       mstore(0x40, add(free, 32))
@@ -64,17 +64,17 @@ contract Usr {
     address debtDestination,
     int256 deltaCollateral,
     int256 deltaDebt
-  ) public returns (bool) {
+  ) public returns (bool ok) {
     string memory _sig = 'modifySAFECollateralization(bytes32,address,address,address,int256,int256)';
     bytes memory _data = abi.encodeWithSignature(
       _sig, _collateralType, safe, collateralSource, debtDestination, deltaCollateral, deltaDebt
     );
+    bytes memory _success;
 
     bytes memory _can_call = abi.encodeWithSignature('try_call(address,bytes)', safeEngine, _data);
-    (bool _ok, bytes memory _success) = address(this).call(_can_call);
+    (ok, _success) = address(this).call(_can_call);
 
-    _ok = abi.decode(_success, (bool));
-    if (_ok) return true;
+    ok = abi.decode(_success, (bool));
   }
 
   function can_transferSAFECollateralAndDebt(
@@ -83,15 +83,15 @@ contract Usr {
     address dst,
     int256 deltaCollateral,
     int256 deltaDebt
-  ) public returns (bool) {
+  ) public returns (bool ok) {
     string memory _sig = 'transferSAFECollateralAndDebt(bytes32,address,address,int256,int256)';
     bytes memory data = abi.encodeWithSignature(_sig, _collateralType, src, dst, deltaCollateral, deltaDebt);
 
     bytes memory can_call = abi.encodeWithSignature('try_call(address,bytes)', safeEngine, data);
-    (bool ok, bytes memory success) = address(this).call(can_call);
+    bytes memory success;
+    (ok, success) = address(this).call(can_call);
 
     ok = abi.decode(success, (bool));
-    if (ok) return true;
   }
 
   function approve(address _token, address _target, uint256 _wad) external {

--- a/test/testnet/single/TransferSAFECollateralAndDebt.t.sol
+++ b/test/testnet/single/TransferSAFECollateralAndDebt.t.sol
@@ -12,10 +12,10 @@ contract Guy {
     safeEngine = safeEngine_;
   }
 
-  function try_call(address addr, bytes calldata data) external returns (bool) {
+  function try_call(address addr, bytes calldata data) external returns (bool ok) {
     bytes memory _data = data;
     assembly {
-      let ok := call(gas(), addr, 0, add(_data, 0x20), mload(_data), 0, 0)
+      ok := call(gas(), addr, 0, add(_data, 0x20), mload(_data), 0, 0)
       let free := mload(0x40)
       mstore(free, ok)
       mstore(0x40, add(free, 32))
@@ -30,17 +30,17 @@ contract Guy {
     address debtDestination,
     int256 deltaCollateral,
     int256 deltaDebt
-  ) public returns (bool) {
+  ) public returns (bool ok) {
     string memory sig = 'modifySAFECollateralization(bytes32,address,address,address,int256,int256)';
     bytes memory data = abi.encodeWithSignature(
       sig, address(this), collateralType, safe, collateralSource, debtDestination, deltaCollateral, deltaDebt
     );
 
+    bytes memory success;
     bytes memory can_call = abi.encodeWithSignature('try_call(address,bytes)', safeEngine, data);
-    (bool ok, bytes memory success) = address(this).call(can_call);
+    (ok, success) = address(this).call(can_call);
 
     ok = abi.decode(success, (bool));
-    if (ok) return true;
   }
 
   function can_transferSAFECollateralAndDebt(
@@ -49,15 +49,15 @@ contract Guy {
     address dst,
     int256 deltaCollateral,
     int256 deltaDebt
-  ) public returns (bool) {
+  ) public returns (bool ok) {
     string memory sig = 'transferSAFECollateralAndDebt(bytes32,address,address,int256,int256)';
     bytes memory data = abi.encodeWithSignature(sig, collateralType, src, dst, deltaCollateral, deltaDebt);
 
     bytes memory can_call = abi.encodeWithSignature('try_call(address,bytes)', safeEngine, data);
-    (bool ok, bytes memory success) = address(this).call(can_call);
+    bytes memory success;
+    (ok, success) = address(this).call(can_call);
 
     ok = abi.decode(success, (bool));
-    if (ok) return true;
   }
 
   function modifySAFECollateralization(


### PR DESCRIPTION
Closes #291 

Silenced about a dozen compiler warnings.

There are more warnings I could silence - but the warnings also feel like reference pointers in unfinished code.  There's also a couple compiler warnings that are in fact bugs; such as the ones in AddCollateral.t.sol as these functions cannot be restricted to view functions. 