### PR TITLE
fixed all e2e stability fee tests

### DIFF
--- a/test/testnet/e2e/Common.t.sol
+++ b/test/testnet/e2e/Common.t.sol
@@ -15,6 +15,8 @@ import {
 import {WETH9} from '@testnet/mocks/WETH9.sol';
 import {Math, RAY} from '@libraries/Math.sol';
 
+import {IDelayedOracle} from '@interfaces/oracles/IDelayedOracle.sol';
+
 uint256 constant RAD_DELTA = 0.0001e45;
 uint256 constant COLLATERAL_PRICE = 100e18;
 
@@ -37,13 +39,11 @@ contract DeployForTest is TestParams, Deploy {
 
     systemCoinOracle = new OracleForTest(OD_INITIAL_PRICE); // 1 OD = 1 USD
 
-    // TODO: fix incorrect conversion
-    // delayedOracle[ETH_A] = new OracleForTest(TEST_ETH_PRICE); // 1 ETH = 2000 USD
-    // delayedOracle[TKN] = new OracleForTest(TEST_TKN_PRICE); // 1 TKN = 1 USD
-
     collateral[WSTETH] = IERC20Metadata(address(weth));
     collateral[TKN] = new ERC20ForTest();
 
+    delayedOracle[WSTETH] = new DelayedOracleForTest(TEST_ETH_PRICE, address(0));
+    delayedOracle[TKN] = new DelayedOracleForTest(TEST_TKN_PRICE, address(0));
     delayedOracle['TKN-A'] = new DelayedOracleForTest(COLLATERAL_PRICE, address(0));
     delayedOracle['TKN-B'] = new DelayedOracleForTest(COLLATERAL_PRICE, address(0));
     delayedOracle['TKN-C'] = new DelayedOracleForTest(COLLATERAL_PRICE, address(0));

--- a/test/testnet/e2e/E2EStabilityFeeTreasury.t.sol
+++ b/test/testnet/e2e/E2EStabilityFeeTreasury.t.sol
@@ -31,7 +31,7 @@ abstract contract E2EStabilityFeeTreasuryTest is BaseUser, Common {
     // giving 25% of the balance to bob
     uint256 _rad = _coinBalance / 4;
 
-    vm.prank(deployer);
+    vm.prank(governor);
     // Executing give funds method with the 25% of the balance
     stabilityFeeTreasury.giveFunds(bob, _rad);
 
@@ -55,7 +55,7 @@ abstract contract E2EStabilityFeeTreasuryTest is BaseUser, Common {
     safeEngine.approveSAFEModification(address(stabilityFeeTreasury));
     _joinCoins(alice, _wad);
 
-    vm.prank(deployer);
+    vm.prank(governor);
     // Executing take funds method with the 100% of alice's balance
     stabilityFeeTreasury.takeFunds(alice, _wad * RAY);
 
@@ -71,22 +71,22 @@ abstract contract E2EStabilityFeeTreasuryTest is BaseUser, Common {
     uint256 _coinBalance = safeEngine.coinBalance(address(stabilityFeeTreasury));
     uint256 _previousAliceBalance = safeEngine.coinBalance(alice);
 
-    vm.startPrank(deployer);
+    vm.startPrank(governor);
     // Executing pulling ~25% of funds and setting alice as destination
     uint256 _rad = _coinBalance / 4;
     uint256 _wad = _rad / RAY;
     _rad = _wad * RAY; // solves internal rounding errors
 
     // Set total allowance to _rad
-    stabilityFeeTreasury.setTotalAllowance(deployer, _rad);
+    stabilityFeeTreasury.setTotalAllowance(governor, _rad);
     stabilityFeeTreasury.pullFunds(alice, _wad);
     vm.stopPrank();
 
     // Assertions
     assertEq(safeEngine.coinBalance(alice), _previousAliceBalance + _rad);
     assertEq(safeEngine.coinBalance(address(stabilityFeeTreasury)), _coinBalance - _rad);
-    assertEq(stabilityFeeTreasury.allowance(deployer).total, 0); // deployer used all allowance
-    assertEq(stabilityFeeTreasury.pulledPerHour(deployer, block.timestamp / HOUR), _rad);
+    assertEq(stabilityFeeTreasury.allowance(governor).total, 0); // governor used all allowance
+    assertEq(stabilityFeeTreasury.pulledPerHour(governor, block.timestamp / HOUR), _rad);
   }
 
   function test_transfer_surplus_funds() public {
@@ -117,7 +117,7 @@ abstract contract E2EStabilityFeeTreasuryTest is BaseUser, Common {
     uint256 _debt = _coinBalance / 2;
 
     // Generating a debt in stabilityFeeTreasury safe
-    vm.startPrank(deployer);
+    vm.startPrank(governor);
     safeEngine.createUnbackedDebt({
       _debtDestination: address(stabilityFeeTreasury),
       _coinDestination: address(0),
@@ -125,7 +125,7 @@ abstract contract E2EStabilityFeeTreasuryTest is BaseUser, Common {
     });
     assertEq(safeEngine.debtBalance(address(stabilityFeeTreasury)), _debt);
 
-    stabilityFeeTreasury.setTotalAllowance(deployer, _rad);
+    stabilityFeeTreasury.setTotalAllowance(governor, _rad);
     stabilityFeeTreasury.pullFunds(alice, _wad);
     vm.stopPrank();
 
@@ -152,8 +152,8 @@ abstract contract E2EStabilityFeeTreasuryTest is BaseUser, Common {
     vm.stopPrank();
 
     // Executing pulling 100% of funds and setting bob as destination
-    vm.startPrank(deployer);
-    stabilityFeeTreasury.setTotalAllowance(deployer, _wad * RAY);
+    vm.startPrank(governor);
+    stabilityFeeTreasury.setTotalAllowance(governor, _wad * RAY);
     stabilityFeeTreasury.pullFunds(bob, _wad);
     vm.stopPrank();
 

--- a/test/testnet/e2e/TestParams.t.sol
+++ b/test/testnet/e2e/TestParams.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import '@script/Params.s.sol';
 
 bytes32 constant TKN = bytes32('TKN');
-uint256 constant TEST_ETH_PRICE = 1000e18; // 1 ETH = 1000 OD
+uint256 constant TEST_ETH_PRICE = 2000e18; // 1 ETH = 1000 OD
 uint256 constant TEST_TKN_PRICE = 1e18; // 1 TKN = 1 OD
 
 uint256 constant INITIAL_DEBT_AUCTION_MINTED_TOKENS = 1e18;


### PR DESCRIPTION
Closes #304 

This one ended up being a bit of a doozy because of a Forge error telling me the test was injecting `LiquidationEngineCollateralParams` ... when that was just a straight up bug.

There was a new collateral constant that was only partially created.  And so there was a mixup between `WSTETH` and `ETH-A` where they were inconsistently indexing the various mappings by cType.  I also went ahead and fixed all the E2E Stability Fee tests while I was at it ... they simply weren't accounting for access control revocation.