### PR TITLE
safeCan nonce fix + test

### DIFF
--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -51,6 +51,8 @@ interface IODSafeManager {
   // --- Structs ---
 
   struct SAFEData {
+    // The current nonce of the safe - incremented each time it is transferred
+    uint96 nonce;
     // Address of the safe owner
     address owner;
     // Address of the safe handler
@@ -65,7 +67,7 @@ interface IODSafeManager {
   function safeEngine() external view returns (address _safeEngine);
 
   /// @notice Mapping of owner and safe permissions to a caller permissions
-  function safeCan(address _owner, uint256 _safeId, address _caller) external view returns (bool _ok);
+  function safeCan(address _owner, uint256 _safeId, uint96 _safeNonce, address _caller) external view returns (bool _ok);
 
   /// @notice Mapping of handler to a caller permissions
   function handlerCan(address _safeHandler, address _caller) external view returns (bool _ok);

--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -67,7 +67,12 @@ interface IODSafeManager {
   function safeEngine() external view returns (address _safeEngine);
 
   /// @notice Mapping of owner and safe permissions to a caller permissions
-  function safeCan(address _owner, uint256 _safeId, uint96 _safeNonce, address _caller) external view returns (bool _ok);
+  function safeCan(
+    address _owner,
+    uint256 _safeId,
+    uint96 _safeNonce,
+    address _caller
+  ) external view returns (bool _ok);
 
   /// @notice Mapping of handler to a caller permissions
   function handlerCan(address _safeHandler, address _caller) external view returns (bool _ok);

--- a/test/testlocal/nft/anvil/NFT.t.sol
+++ b/test/testlocal/nft/anvil/NFT.t.sol
@@ -279,7 +279,9 @@ contract NFTAnvil is AnvilFork {
 
     IODSafeManager.SAFEData memory sData = safeManager.safeData(vaultId);
 
-    assertEq(safeManager.safeCan(sData.owner, vaultId, sData.nonce, users[i]), ok, 'test_allowSAFE: safeCan not set correctly');
+    assertEq(
+      safeManager.safeCan(sData.owner, vaultId, sData.nonce, users[i]), ok, 'test_allowSAFE: safeCan not set correctly'
+    );
   }
 
   function test_allowHandler(uint256 cTypeIndex, bool ok) public {

--- a/test/testlocal/nft/anvil/NFT.t.sol
+++ b/test/testlocal/nft/anvil/NFT.t.sol
@@ -279,7 +279,7 @@ contract NFTAnvil is AnvilFork {
 
     IODSafeManager.SAFEData memory sData = safeManager.safeData(vaultId);
 
-    assertEq(safeManager.safeCan(sData.owner, vaultId, users[i]), ok, 'test_allowSAFE: safeCan not set correctly');
+    assertEq(safeManager.safeCan(sData.owner, vaultId, sData.nonce, users[i]), ok, 'test_allowSAFE: safeCan not set correctly');
   }
 
   function test_allowHandler(uint256 cTypeIndex, bool ok) public {
@@ -404,4 +404,25 @@ contract NFTAnvil is AnvilFork {
   //   protectSAFE(proxy, vaultId, address(liquidationEngine), saviour);
   //   vm.stopPrank();
   // }
+
+  // If the nonce increments, then after each vault transfer
+  // all previous allowSAFE calls will be invalidated
+  // as safeAllowed looks at the current nonce
+  function test_transferFromIncrementsNonce(uint256 cTypeIndex) public {
+    cTypeIndex = bound(cTypeIndex, 1, cTypes.length - 1); // range: WSTETH, CBETH, RETH, MAGIC
+
+    uint256 vaultId = vaultIds[proxies[0]][cTypes[cTypeIndex]];
+
+    IODSafeManager.SAFEData memory sData = safeManager.safeData(vaultId);
+
+    assertEq(sData.nonce, 0, 'test_transerFromIncrementsNonce: nonce not equal');
+
+    vm.startPrank(users[0]);
+    vault721.transferFrom(users[0], users[1], vaultId);
+    vm.stopPrank();
+
+    sData = safeManager.safeData(vaultId);
+
+    assertEq(sData.nonce, 1, 'test_transerFromIncrementsNonce: nonce not equal');
+  }
 }

--- a/test/testlocal/nft/anvil/governor/Proposal.t.sol
+++ b/test/testlocal/nft/anvil/governor/Proposal.t.sol
@@ -402,9 +402,12 @@ contract GovernanceProposalAnvil is AnvilFork {
     calldatas[0] = abi.encodeWithSelector(selector, 'seedProposer', abi.encode(params.seedProposer));
     calldatas[1] = abi.encodeWithSelector(selector, 'noiseBarrier', abi.encode(params.noiseBarrier));
     calldatas[2] = abi.encodeWithSelector(selector, 'integralPeriodSize', abi.encode(params.integralPeriodSize));
-    calldatas[3] = abi.encodeWithSelector(selector, 'feedbackOutputUpperBound', abi.encode(params.feedbackOutputUpperBound));
-    calldatas[4] = abi.encodeWithSelector(selector, 'feedbackOutputLowerBound', abi.encode(params.feedbackOutputLowerBound));
-    calldatas[5] = abi.encodeWithSelector(selector, 'perSecondCumulativeLeak', abi.encode(params.perSecondCumulativeLeak));
+    calldatas[3] =
+      abi.encodeWithSelector(selector, 'feedbackOutputUpperBound', abi.encode(params.feedbackOutputUpperBound));
+    calldatas[4] =
+      abi.encodeWithSelector(selector, 'feedbackOutputLowerBound', abi.encode(params.feedbackOutputLowerBound));
+    calldatas[5] =
+      abi.encodeWithSelector(selector, 'perSecondCumulativeLeak', abi.encode(params.perSecondCumulativeLeak));
     calldatas[6] = abi.encodeWithSelector(selector, 'kp', abi.encode(params.kp));
     calldatas[7] = abi.encodeWithSelector(selector, 'ki', abi.encode(params.ki));
 


### PR DESCRIPTION
closes #217 

NOTE: I'm not sure why, but this test breaks `yarn deploy:anvil`. 
It removes `NFTRenderer_Address` and `GlobalSettlementActions_Address` from `AnvilContracts.t.sol`.