### PR TITLE
Handlercan nonce fix

### DIFF
--- a/src/contracts/proxies/ODSafeManager.sol
+++ b/src/contracts/proxies/ODSafeManager.sol
@@ -46,8 +46,6 @@ contract ODSafeManager is IODSafeManager {
   mapping(address _safeHandler => mapping(uint96 _safeNonce => mapping(address _caller => bool _ok))) public handlerCan;
   /// @inheritdoc IODSafeManager
   mapping(address _safeHandler => uint256 _safeId) public safeHandlerToSafeId;
-  /// @inheritdoc IODSafeManager
-  mapping(address _safeHandler => bool _exists) public handlerExists;
 
   // --- Modifiers ---
 
@@ -154,9 +152,6 @@ contract ODSafeManager is IODSafeManager {
 
     safeHandlerToSafeId[_safeHandler] = _safeId;
 
-    // Save the address of the safeHandler
-    handlerExists[_safeHandler] = true;
-
     _usrSafes[_usr].add(_safeId);
     _usrSafesPerCollat[_usr][_cType].add(_safeId);
 
@@ -212,7 +207,7 @@ contract ODSafeManager is IODSafeManager {
   /// @inheritdoc IODSafeManager
   function transferCollateral(uint256 _safe, address _dst, uint256 _wad) external safeAllowed(_safe) {
     SAFEData memory _sData = _safeData[_safe];
-    if (!handlerExists[_dst]) revert HandlerDoesNotExist();
+    if (safeHandlerToSafeId[_dst] == 0) revert HandlerDoesNotExist();
 
     ISAFEEngine(safeEngine).transferCollateral(_sData.collateralType, _sData.safeHandler, _dst, _wad);
 

--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -67,10 +67,18 @@ interface IODSafeManager {
   function safeEngine() external view returns (address _safeEngine);
 
   /// @notice Mapping of owner and safe permissions to a caller permissions
-  function safeCan(address _owner, uint256 _safeId, uint96 _safeNonce, address _caller) external view returns (bool _ok);
+  function safeCan(
+    address _owner,
+    uint256 _safeId,
+    uint96 _safeNonce,
+    address _caller
+  ) external view returns (bool _ok);
 
   /// @notice Mapping of handler to a caller permissions
-  function handlerCan(address _safeHandler, address _caller) external view returns (bool _ok);
+  function handlerCan(address _safeHandler, uint96 _safeNonce, address _caller) external view returns (bool _ok);
+
+  /// @notice Mapping of handler to the safeId
+  function safeHandlerToSafeId(address _safeHandler) external view returns (uint256 _safeId);
 
   /// @notice Mapping of handler to whether it exists
   function handlerExists(address _safeHandler) external view returns (bool _exists);
@@ -103,6 +111,13 @@ interface IODSafeManager {
     external
     view
     returns (uint256[] memory _safes, address[] memory _safeHandlers, bytes32[] memory _cTypes);
+
+  /**
+   * @notice Getter for the details of the safe given a handler address
+   * @param  _handler Address of the handler
+   * @return _sData Struct with the safe data
+   */
+  function getSafeDataFromHandler(address _handler) external view returns (SAFEData memory _sData);
 
   /**
    * @notice Getter for the details of a SAFE

--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -51,6 +51,8 @@ interface IODSafeManager {
   // --- Structs ---
 
   struct SAFEData {
+    // The current nonce of the safe - incremented each time it is transferred
+    uint96 nonce;
     // Address of the safe owner
     address owner;
     // Address of the safe handler
@@ -65,7 +67,7 @@ interface IODSafeManager {
   function safeEngine() external view returns (address _safeEngine);
 
   /// @notice Mapping of owner and safe permissions to a caller permissions
-  function safeCan(address _owner, uint256 _safeId, address _caller) external view returns (bool _ok);
+  function safeCan(address _owner, uint256 _safeId, uint96 _safeNonce, address _caller) external view returns (bool _ok);
 
   /// @notice Mapping of handler to a caller permissions
   function handlerCan(address _safeHandler, address _caller) external view returns (bool _ok);

--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -80,9 +80,6 @@ interface IODSafeManager {
   /// @notice Mapping of handler to the safeId
   function safeHandlerToSafeId(address _safeHandler) external view returns (uint256 _safeId);
 
-  /// @notice Mapping of handler to whether it exists
-  function handlerExists(address _safeHandler) external view returns (bool _exists);
-
   // --- Getters ---
 
   /**

--- a/test/testlocal/nft/anvil/NFT.t.sol
+++ b/test/testlocal/nft/anvil/NFT.t.sol
@@ -279,7 +279,7 @@ contract NFTAnvil is AnvilFork {
 
     IODSafeManager.SAFEData memory sData = safeManager.safeData(vaultId);
 
-    assertEq(safeManager.safeCan(sData.owner, vaultId, users[i]), ok, 'test_allowSAFE: safeCan not set correctly');
+    assertEq(safeManager.safeCan(sData.owner, vaultId, sData.nonce, users[i]), ok, 'test_allowSAFE: safeCan not set correctly');
   }
 
   function test_allowHandler(uint256 cTypeIndex, bool ok) public {
@@ -404,4 +404,25 @@ contract NFTAnvil is AnvilFork {
   //   protectSAFE(proxy, vaultId, address(liquidationEngine), saviour);
   //   vm.stopPrank();
   // }
+
+  // If the nonce increments, then after each vault transfer
+  // all previous allowSAFE calls will be invalidated
+  // as safeAllowed looks at the current nonce
+  function test_transferFromIncrementsNonce(uint256 cTypeIndex) public {
+    cTypeIndex = bound(cTypeIndex, 1, cTypes.length - 1); // range: WSTETH, CBETH, RETH, MAGIC
+
+    uint256 vaultId = vaultIds[proxies[0]][cTypes[cTypeIndex]];
+
+    IODSafeManager.SAFEData memory sData = safeManager.safeData(vaultId);
+
+    assertEq(sData.nonce, 0, 'test_transerFromIncrementsNonce: nonce not equal');
+
+    vm.startPrank(users[0]);
+    vault721.transferFrom(users[0], users[1], vaultId);
+    vm.stopPrank();
+
+    sData = safeManager.safeData(vaultId);
+
+    assertEq(sData.nonce, 1, 'test_transerFromIncrementsNonce: nonce not equal');
+  }
 }

--- a/test/testlocal/nft/anvil/NFT.t.sol
+++ b/test/testlocal/nft/anvil/NFT.t.sol
@@ -279,7 +279,9 @@ contract NFTAnvil is AnvilFork {
 
     IODSafeManager.SAFEData memory sData = safeManager.safeData(vaultId);
 
-    assertEq(safeManager.safeCan(sData.owner, vaultId, sData.nonce, users[i]), ok, 'test_allowSAFE: safeCan not set correctly');
+    assertEq(
+      safeManager.safeCan(sData.owner, vaultId, sData.nonce, users[i]), ok, 'test_allowSAFE: safeCan not set correctly'
+    );
   }
 
   function test_allowHandler(uint256 cTypeIndex, bool ok) public {
@@ -294,7 +296,9 @@ contract NFTAnvil is AnvilFork {
 
     IODSafeManager.SAFEData memory sData = safeManager.safeData(vaultId);
 
-    assertEq(safeManager.handlerCan(proxy, users[i]), ok, 'test_allowHandler: handlerCan not set correctly');
+    assertEq(
+      safeManager.handlerCan(proxy, sData.nonce, users[i]), ok, 'test_allowHandler: handlerCan not set correctly'
+    );
   }
 
   // function test_modifySAFECollateralization(
@@ -406,7 +410,7 @@ contract NFTAnvil is AnvilFork {
   // }
 
   // If the nonce increments, then after each vault transfer
-  // all previous allowSAFE calls will be invalidated
+  // all previous allowSAFE/allowHandler calls will be invalidated
   // as safeAllowed looks at the current nonce
   function test_transferFromIncrementsNonce(uint256 cTypeIndex) public {
     cTypeIndex = bound(cTypeIndex, 1, cTypes.length - 1); // range: WSTETH, CBETH, RETH, MAGIC

--- a/test/testlocal/nft/anvil/governor/Proposal.t.sol
+++ b/test/testlocal/nft/anvil/governor/Proposal.t.sol
@@ -402,9 +402,12 @@ contract GovernanceProposalAnvil is AnvilFork {
     calldatas[0] = abi.encodeWithSelector(selector, 'seedProposer', abi.encode(params.seedProposer));
     calldatas[1] = abi.encodeWithSelector(selector, 'noiseBarrier', abi.encode(params.noiseBarrier));
     calldatas[2] = abi.encodeWithSelector(selector, 'integralPeriodSize', abi.encode(params.integralPeriodSize));
-    calldatas[3] = abi.encodeWithSelector(selector, 'feedbackOutputUpperBound', abi.encode(params.feedbackOutputUpperBound));
-    calldatas[4] = abi.encodeWithSelector(selector, 'feedbackOutputLowerBound', abi.encode(params.feedbackOutputLowerBound));
-    calldatas[5] = abi.encodeWithSelector(selector, 'perSecondCumulativeLeak', abi.encode(params.perSecondCumulativeLeak));
+    calldatas[3] =
+      abi.encodeWithSelector(selector, 'feedbackOutputUpperBound', abi.encode(params.feedbackOutputUpperBound));
+    calldatas[4] =
+      abi.encodeWithSelector(selector, 'feedbackOutputLowerBound', abi.encode(params.feedbackOutputLowerBound));
+    calldatas[5] =
+      abi.encodeWithSelector(selector, 'perSecondCumulativeLeak', abi.encode(params.perSecondCumulativeLeak));
     calldatas[6] = abi.encodeWithSelector(selector, 'kp', abi.encode(params.kp));
     calldatas[7] = abi.encodeWithSelector(selector, 'ki', abi.encode(params.ki));
 


### PR DESCRIPTION
closes #219 
similar to #346 - review #346 first and close to see the actual changeset in this one

Which means it has the same issue mentioned in #346.

We reuse the nonce saved in `_safeData` to invalidate `handlerCan` in addition to `safeCan`.

`handlerExists` can be removed in favor of `safeHandlerToSafeId`, as long as this invariant holds true: safeId is never 0 for any safe handlers, then `handlerExists` if `safeHandlerToSafeId != 0`.