### PR TITLE
Sepolia deployment 01 16 2024

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendollar/contracts",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "private": true,
   "description": "Multicollateral ETH backed stablecoin",
   "homepage": "https://www.opendollar.com/",

--- a/script/Registry.s.sol
+++ b/script/Registry.s.sol
@@ -9,8 +9,9 @@ uint256 constant SEMI_RANDOM_SALT = 0; // set to 0 to use Salts below, set to 1 
 // Create2 Factory
 address constant TEST_CREATE2FACTORY = 0xC5f2C81d16764908B18379D95f410912d928Adc2;
 
-// Protocol Token
+// Tokens
 address constant SEPOLIA_PROTOCOL_TOKEN = 0x00D2363Ea723d8Bc3D664b87Cf51A04033BD0Ef1;
+address constant SEPOLIA_SYSTEM_COIN = 0x00D0f23771915A857d6483C7734838b87Fc90fD2;
 
 // Governance Settings
 uint256 constant TEST_INIT_VOTING_DELAY = 1;

--- a/script/SepoliaContracts.s.sol
+++ b/script/SepoliaContracts.s.sol
@@ -2,79 +2,69 @@
 pragma solidity 0.8.19;
 
 abstract contract SepoliaContracts {
-  address public ChainlinkRelayerFactory_Address = 0x3fff8D2ce36BB6E578C8621013D30E8b3C4a8690;
-  address public CamelotRelayerFactory_Address = 0xc124E36fa145A529d318F18038DFD1f3f0DF0179;
-  address public DenominatedOracleFactory_Address = 0xc44182c35dA6d8319F3681b096B4F0173Ff70918;
-  address public DelayedOracleFactory_Address = 0xeF1ef23EC091C942efA15a609C2F93Da898C5474;
-  address public MintableVoteERC20_Address = 0x7Ff1f29BbFee60cFC4f004E9C8B58b57Ff003b3a;
-  address public MintableERC20_WSTETH_Address = 0x93b19315A575532907DeB0FA63Bbd74972934784;
-  address public MintableERC20_CBETH_Address = 0x11afeD730373251392b4bA3D146a334196998201;
-  address public MintableERC20_RETH_Address = 0xfaB4E79F883620CE5F9d65F4f760FF706475BFca;
-  address public MintableERC20_MAGIC_Address = 0x0F97Fc4b35b1C3c8c9fd6E723ebed6C267e6E2dd;
-  address public DenominatedOracleChild_12_Address = 0xC15B7Bd08d7FE4553f663085FDDe5C9953359E3E;
-  address public DenominatedOracleChild_14_Address = 0xACF0d145c99D5538963b806F17B25a3539E48Ecf;
-  address public DenominatedOracleChild_16_Address = 0x2cAE16a838D61b5C751703132c76B69b5A1b562f;
-  address public DelayedOracleChild_ARB_Address = 0x786B9E108263836E77acE4ac1231993f205b3BA2;
-  address public DelayedOracleChild_WSTETH_Address = 0x485AbEF546A419a2b8B58B8127EC91f8Cc27d1D2;
-  address public DelayedOracleChild_CBETH_Address = 0xccf180F3b4C7af1ee7e28035E2682A86b41e1Bed;
-  address public DelayedOracleChild_RETH_Address = 0x98F8580B572f0604bD5B5E48c200065a4889ba61;
-  address public DelayedOracleChild_MAGIC_Address = 0xc6d884Ec4C44D7F2B2041E012c429586a4ec1025;
-  address public SystemCoin_Address = 0x94beB5fC16824338Eaa538c3c857D7f7fFf4B2Ce;
-  address public ProtocolToken_Address = 0x22d953bc460246199a02A4c6C2dAA929335645d0;
-  address public TimelockController_Address = 0x136b4402EE09ceC0e74D8aFf253d7d5DF39Bc9F4;
-  address public ODGovernor_Address = 0x56a775aeD19836ba3C6db8155dF935d38dE3aD1A;
-  address public SAFEEngine_Address = 0x30fdA32a673Af230D69cb4A11a6125D7E7E4c11D;
-  address public OracleRelayer_Address = 0x9978BBC228B5dAf625315a4A7696f0f0D3930fDa;
-  address public SurplusAuctionHouse_Address = 0x0eFe9B7aF21C8d345fff787082bbB5fc7B07BA82;
-  address public DebtAuctionHouse_Address = 0x750ecadB0086F28e541f09eF11a759a5548E97f9;
-  address public AccountingEngine_Address = 0x62c7CAE5c017016BEd5f404FD23D43a097f1d9Ba;
-  address public LiquidationEngine_Address = 0xd99Ea0A9566d7e5d7e3bB504E7Ea5851dD1BF35f;
-  address public CollateralAuctionHouseFactory_Address = 0x56Cae2E66D0Dd4C0e6f1944B82F3C082DCCe41EF;
-  address public CoinJoin_Address = 0x266358F318D9b331Ba06cabb1f2A2211FE2BFF44;
-  address public CollateralJoinFactory_Address = 0x8E68B53d0c3d3f4A9bDffD87782949041395019C;
-  address public TaxCollector_Address = 0xFefAd2d690895604c8588e4d5bEE31261D06A620;
-  address public StabilityFeeTreasury_Address = 0x8b68dda01E3c17edeb2fb03c6e390D25b906f8A2;
-  address public GlobalSettlement_Address = 0x5e6F4CF324cf9f8Dbb27f4E9Abb2d00f8000Ed27;
-  address public PostSettlementSurplusAuctionHouse_Address = 0x03355b951eD8936902eF21073A1c370E9d9Ac432;
-  address public SettlementSurplusAuctioneer_Address = 0x1D6AC552B5f642A82dbB1e2697a0c1fa9585e02d;
-  address public PIDController_Address = 0xfBF482CEdA400487aa740f602A1f51431aA8a4bc;
-  address public PIDRateSetter_Address = 0x39192F857b0909ddC4d5B5272383C3c0b43a3967;
-  address public AccountingJob_Address = 0x3D65B41898dB1504C78497A0f4FAe7a926355A5B;
-  address public LiquidationJob_Address = 0x08D43780b55F31bAeE80199Bef527C9BeF4D5A28;
-  address public OracleJob_Address = 0xC4813f7ca4b73A94b3077D5bADBDca1be1222735;
+  address public ChainlinkRelayerFactory_Address = 0x7C7De459742428AE0786d1d2aCF5100Db1EB0387;
+  address public DenominatedOracleFactory_Address = 0xd8d4D616dB32164362Cf9904a6c1936a807B0297;
+  address public DelayedOracleFactory_Address = 0x4eB15BDeb24031271c61b6f1671E08DFc809e979;
+  address public MintableVoteERC20_Address = 0x2F6aeB8D80C0726DEec970F615769f1c989d36b2;
+  address public MintableERC20_WSTETH_Address = 0xC586f5022D13de3462bC5456b8F895ef49b02Fb2;
+  address public MintableERC20_CBETH_Address = 0x098bbDB3575CA05273837043f9F59946C62201e4;
+  address public MintableERC20_RETH_Address = 0x2bF2A9E3A07B9f75fC1b36D56Efd6999b3AF7951;
+  address public ChainlinkRelayerChild_8_Address = 0xaD5cA8531180Ab7C0C4666C1e3cCC990A7Aa63ec;
+  address public DenominatedOracleChild_10_Address = 0xAdB4104165b0714F334457a47Cd7fdbc73949a7C;
+  address public DenominatedOracleChild_12_Address = 0x018903c59D1b254ca8be5FEc27f17747B661Bac2;
+  address public DelayedOracleChild_ARB_Address = 0x4cA03fa8711cD805e1e0731cfE453F381753A5fc;
+  address public DelayedOracleChild_WSTETH_Address = 0x4F3d439e1f48F853DF1b50dAbc1Cb45A92F38d64;
+  address public DelayedOracleChild_CBETH_Address = 0xBbb6d4aa590C98E51A65D9C3c577a435820bDc54;
+  address public DelayedOracleChild_RETH_Address = 0x0273627e51693bF8Ff4B384bf9978df72E1b7263;
+  address public TimelockController_Address = 0x3D2DA0286758841b59881bc64f821F1FB0Dbe284;
+  address public ODGovernor_Address = 0x8132fbC8A9C58C0B35966DB9221F6698aBe1a8FE;
+  address public SAFEEngine_Address = 0xBa3a99892B601eFc34F51082AeAc521f322E4980;
+  address public OracleRelayer_Address = 0x65a5C8952248AA105cAcD7aB6E2c007bb4B69F94;
+  address public SurplusAuctionHouse_Address = 0xCACA0b053d46bDFfea441Cef3364cc4582c72e23;
+  address public DebtAuctionHouse_Address = 0xaC427c92a5c3a687c1F8Fa95b885f535f1034FC4;
+  address public AccountingEngine_Address = 0x6C0EB178388446CdC0818F8b4ca80d872B598e0c;
+  address public LiquidationEngine_Address = 0x5CFc443Db66A8e8C39D9c769fD5EE1c139BaD159;
+  address public CollateralAuctionHouseFactory_Address = 0xd31D7574080F2b29Bd61a4037428629b445c35cC;
+  address public CoinJoin_Address = 0x2f01Ff86E91EAe7fcEFD7dC7339F74aaB58F0943;
+  address public CollateralJoinFactory_Address = 0x6Ff1fe02B2E64338Ed8E25B44AeB084A086121DC;
+  address public TaxCollector_Address = 0xF0A280223d037F5c2e0Bd345963b2dF7AE697ef4;
+  address public StabilityFeeTreasury_Address = 0x0dE9E5252BEBb25abD4b1992E49f8CC352060fC8;
+  address public GlobalSettlement_Address = 0x78FfF4E713EaEd0329E907788F037A170124eE88;
+  address public PostSettlementSurplusAuctionHouse_Address = 0x53aCAec26afBfad20a2C92CA7f555e2ABC707a21;
+  address public SettlementSurplusAuctioneer_Address = 0x7A83F5Ab23210d1Eb050aFE5f7e9E9a454782ea6;
+  address public PIDController_Address = 0x9a18558741691D07618f3D06a883077E528fA9ad;
+  address public PIDRateSetter_Address = 0xf65E9F9d2A939069D6FE07d6a7F12a81d4013cf6;
+  address public AccountingJob_Address = 0x5178C1A616CaF67184104Cc6555c0310bbB7F6d5;
+  address public LiquidationJob_Address = 0xD1D1a18a459d9Be1a7C237578DF1aB3CFf051282;
+  address public OracleJob_Address = 0x67cAD916b2572708E352eDE3A16E54F8d353ebDB;
   address public CollateralJoinChild_0x4152420000000000000000000000000000000000000000000000000000000000_Address =
-    0x5900EB92788168A8Fa518461652E889f2caBA199;
+    0xF14405230f195287d426616bE103B5227815D40F;
   address public
     CollateralAuctionHouseChild_0x4152420000000000000000000000000000000000000000000000000000000000_Address =
-      0x7A8152bb519b399e85d446fFe2F432D75AEA6bf9;
+      0xbb5484cd846685152b0758Fd7265763Fb095698A;
   address public CollateralJoinChild_0x5753544554480000000000000000000000000000000000000000000000000000_Address =
-    0xE0dF883Bc3a60Ef8e5522d7B5fE03ee2E5e4e31b;
+    0x7B6583a843b41E5CB3E52055452052813496958C;
   address public
     CollateralAuctionHouseChild_0x5753544554480000000000000000000000000000000000000000000000000000_Address =
-      0x9d71cff8e3E2B0DC53983f9E3F38142EE99F8AB8;
+      0x965f467706bE40f2020e0eFa85Ef38607d592c65;
   address public CollateralJoinChild_0x4342455448000000000000000000000000000000000000000000000000000000_Address =
-    0xC40e96b01f526943596bd57854DAD4285878B989;
+    0x4BaD88483C9C98b76A0eF4413B6f5F19fF5f76D5;
   address public
     CollateralAuctionHouseChild_0x4342455448000000000000000000000000000000000000000000000000000000_Address =
-      0x56c04D90766bf64426037680d6bC79fEdba47E79;
+      0xEe54B801ac028d76d35290816b0b18383b404254;
   address public CollateralJoinChild_0x5245544800000000000000000000000000000000000000000000000000000000_Address =
-    0x165b9CcB20cc313131c0152450dB91a7ee14E21e;
+    0xD5Caf52F4f2365789f5dC75b5847A5873DABad95;
   address public
     CollateralAuctionHouseChild_0x5245544800000000000000000000000000000000000000000000000000000000_Address =
-      0x88A755ee64e48A3dd239D6d0989D1e27E518ABE8;
-  address public CollateralJoinChild_0x4d41474943000000000000000000000000000000000000000000000000000000_Address =
-    0x05f8230CD0C85c43d9a7eDf26532F39B9D7E1896;
-  address public
-    CollateralAuctionHouseChild_0x4d41474943000000000000000000000000000000000000000000000000000000_Address =
-      0x7eeF092e0e89d46986C987Dfb89AA306fc2374d0;
-  address public Vault721_Address = 0x677Bd90AB6A27552D0744a0Af196DA127f014656;
-  address public ODSafeManager_Address = 0xA3EF1c4ef0FDC10501C6F907b004Be3A5905be65;
-  address public NFTRenderer_Address = 0x3319c348323aE1FDDA7b33995049f757A78fEDc3;
-  address public BasicActions_Address = 0xeE34Cda23dAF9C92D417379dc258825311420bb2;
-  address public DebtBidActions_Address = 0xe98882f63F1d1F749f627Ef2BA4D86B3c597Cb59;
-  address public SurplusBidActions_Address = 0xb4Efb9a37f0af1b7316f2e4df52A8eB541306263;
-  address public CollateralBidActions_Address = 0xEbAB30335CB9D05B3edC9CFb38b7663f7047da4A;
-  address public PostSettlementSurplusBidActions_Address = 0x3BC35240184d6ddd63d189fEa5328deA0906FD7C;
-  address public GlobalSettlementActions_Address = 0x9fD3826e3C89EE7f2808D877117A55d732EBa477;
-  address public RewardedActions_Address = 0x2A2C3C71107E390FDB0862d835B638bfC7064c50;
+      0x3e9D80DD8538222d81dF41cd001D4aDcb096CFc4;
+  address public Vault721_Address = 0x445f4bc91D3d96C968044328bF8cE59A7C2D56Da;
+  address public ODSafeManager_Address = 0xf98Ef7Ba4E5BaDaD414eAec6EA90DF29fcA75142;
+  address public NFTRenderer_Address = 0xa8E7A8A2781269eBee86289C18d42fc5952C9919;
+  address public BasicActions_Address = 0x053dDd9738Aa8072cF48B19fC176e94351f960f6;
+  address public DebtBidActions_Address = 0xfcAB538555b3aea34181D60e63eB033c008031B9;
+  address public SurplusBidActions_Address = 0x468bAA010369E06aB27B011601881cfFEf122fc6;
+  address public CollateralBidActions_Address = 0x01d1e78695268cb95876C2Be35409fB3Fd73Af4B;
+  address public PostSettlementSurplusBidActions_Address = 0x8d76F570c496EA43B0163B834D8b3232a4cDffFB;
+  address public GlobalSettlementActions_Address = 0xa0D4fCe94F3FA94A820D471791ccb35D166672a2;
+  address public RewardedActions_Address = 0xC7a8CCFF6f09dC536c164bA6448F87553d60778D;
 }

--- a/script/SepoliaDeployment.s.sol
+++ b/script/SepoliaDeployment.s.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
+import '@script/Registry.s.sol';
 import '@script/Contracts.s.sol';
 import {SepoliaParams, WSTETH, ARB, CBETH, RETH} from '@script/SepoliaParams.s.sol';
 import {SepoliaContracts} from '@script/SepoliaContracts.s.sol';
@@ -26,8 +27,8 @@ abstract contract SepoliaDeployment is Contracts, SepoliaParams, SepoliaContract
     collateral[CBETH] = IERC20Metadata(MintableERC20_CBETH_Address);
     collateral[RETH] = IERC20Metadata(MintableERC20_RETH_Address);
 
-    systemCoin = SystemCoin(SystemCoin_Address);
-    protocolToken = ProtocolToken(ProtocolToken_Address);
+    systemCoin = SystemCoin(SEPOLIA_SYSTEM_COIN);
+    protocolToken = ProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
 
     // --- base contracts ---
     safeEngine = SAFEEngine(SAFEEngine_Address);

--- a/script/testScripts/gov/DeployGovernor.s.sol
+++ b/script/testScripts/gov/DeployGovernor.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
+import '@script/Registry.s.sol';
 import {Script} from 'forge-std/Script.sol';
 import {SepoliaContracts} from '@script/SepoliaContracts.s.sol';
 import {ODGovernor} from '@contracts/gov/ODGovernor.sol';
 import {TimelockController} from '@openzeppelin/governance/TimelockController.sol';
-import '@script/Registry.s.sol';
 
 // BROADCAST
 // source .env && forge script DeployGovernor --with-gas-price 2000000000 -vvvvv --rpc-url $ARB_SEPOLIA_RPC --broadcast --verify --etherscan-api-key $ARB_ETHERSCAN_API_KEY
@@ -30,7 +30,7 @@ contract DeployGovernor is SepoliaContracts, Script {
       TEST_INIT_VOTING_DELAY,
       TEST_INIT_VOTING_PERIOD,
       TEST_INIT_PROP_THRESHOLD,
-      ProtocolToken_Address,
+      SEPOLIA_PROTOCOL_TOKEN,
       timelockController
     );
     vm.stopBroadcast();

--- a/script/testScripts/user/utils/Deployment.s.sol
+++ b/script/testScripts/user/utils/Deployment.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import 'forge-std/Script.sol';
+import '@script/Registry.s.sol';
 import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
 
 import {SepoliaContracts} from '@script/SepoliaContracts.s.sol';
@@ -60,15 +61,12 @@ contract Deployment is Contracts, SepoliaContracts, Script {
     collateralBidActions = CollateralBidActions(CollateralBidActions_Address);
     rewardedActions = RewardedActions(RewardedActions_Address);
 
-    protocolToken = ProtocolToken(ProtocolToken_Address); // OPEN
-    systemCoin = SystemCoin(SystemCoin_Address); // OD
+    protocolToken = ProtocolToken(SEPOLIA_PROTOCOL_TOKEN); // OPEN
+    systemCoin = SystemCoin(SEPOLIA_SYSTEM_COIN); // OD
 
     taxCollector = TaxCollector(TaxCollector_Address);
     coinJoin = CoinJoin(CoinJoin_Address);
     collateralJoin[WSTETH] =
       CollateralJoin(CollateralJoinChild_0x5753544554480000000000000000000000000000000000000000000000000000_Address);
-
-    // MintableERC20(address(WETH_TOKEN)).mint(USER1, 1_000_000 ether);
-    // MintableERC20(address(WETH_TOKEN)).mint(USER2, 1_000_000 ether);
   }
 }

--- a/src/contracts/proxies/ODProxy.sol
+++ b/src/contracts/proxies/ODProxy.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.19;
 
 // Open Dollar
-// Version 1.5.8
+// Version 1.5.9
 
 contract ODProxy {
   error TargetAddressRequired();

--- a/src/contracts/proxies/Vault721.sol
+++ b/src/contracts/proxies/Vault721.sol
@@ -9,7 +9,7 @@ import {ODProxy} from '@contracts/proxies/ODProxy.sol';
 import {NFTRenderer} from '@contracts/proxies/NFTRenderer.sol';
 
 // Open Dollar
-// Version 1.5.8
+// Version 1.5.9
 
 struct HashState {
   bytes32 lastHash;


### PR DESCRIPTION
### Audit Fixes

Each audit finding is listed below with the relevant pull request to resolve the issue.

High Risk (2) 🚨🚨

- [26](https://github.com/code-423n4/2023-10-opendollar-findings/issues/26) (Sabnock https://github.com/open-dollar/od-contracts/pull/254) - incorrect calculation of surplus auctions creates surplus imbalance
- [24](https://github.com/code-423n4/2023-10-opendollar-findings/issues/24) (https://github.com/open-dollar/od-contracts/pull/253) -  missing debt check allows for debt auctions of non-existent debt

Medium and low Risk:

- [429](https://github.com/code-423n4/2023-10-opendollar-findings/issues/429) - (https://github.com/open-dollar/od-contracts/pull/288#pullrequestreview-1781807220) proxy actions is missing methods from SafeManager
- [381](https://github.com/code-423n4/2023-10-opendollar-findings/issues/381) - (https://github.com/open-dollar/od-contracts/pull/271) updating address Vault721.safeManager breaks NFV minting
- [371](https://github.com/code-423n4/2023-10-opendollar-findings/issues/371) (https://github.com/open-dollar/od-contracts/pull/251) - save deltaDebt to variable before modifying collateralization
- [323](https://github.com/code-423n4/2023-10-opendollar-findings/issues/323) (https://github.com/open-dollar/od-relayer/pull/8) - allow 18+ decimal token reads from LP relayer
- [286](https://github.com/code-423n4/2023-10-opendollar-findings/issues/286) (https://github.com/open-dollar/od-contracts/pull/245) - taxes can be bypassed with fake taxCollector address
- [267](https://github.com/code-423n4/2023-10-opendollar-findings/issues/267) (https://github.com/open-dollar/od-contracts/pull/226	) - prevent collateral transfers to non-SafeHandlers
- [243](https://github.com/code-423n4/2023-10-opendollar-findings/issues/243) - (https://github.com/open-dollar/od-contracts/pull/209) comply with ERC721 Metadata spec
- [202](https://github.com/code-423n4/2023-10-opendollar-findings/issues/202) (https://github.com/open-dollar/od-contracts/pull/261) - update voting delay and period on GovernorSettings
- [187](https://github.com/code-423n4/2023-10-opendollar-findings/issues/187) (https://github.com/open-dollar/od-contracts/pull/260) - 
this is part of a current PR 
- [171](https://github.com/code-423n4/2023-10-opendollar-findings/issues/171) (https://github.com/open-dollar/od-contracts/pull/278) - approved addresses to a safe can approve other addresses
- [142](https://github.com/code-423n4/2023-10-opendollar-findings/issues/142) (https://github.com/open-dollar/od-contracts/pull/346) - ensure approvals are reset to empty on transferSAFEOwnership
- [382](https://github.com/code-423n4/2023-10-opendollar-findings/issues/382) (https://github.com/open-dollar/od-contracts/pull/347) - inherited `handlerCan` mapping exists without use
- [297](https://github.com/code-423n4/2023-10-opendollar-findings/issues/297) (https://github.com/open-dollar/od-contracts/pull/259) - add functionality in SafeHandler to be able to call allowHandler method
- [159](https://github.com/code-423n4/2023-10-opendollar-findings/issues/159) (https://github.com/open-dollar/od-contracts/pull/269) - wrong collateral is transferred
- [156](https://github.com/code-423n4/2023-10-opendollar-findings/issues/156) (https://github.com/open-dollar/od-contracts/issues/165) - camelot relayer is broken