### PR TITLE
accounting engine test fixes; no longer transfer extra surplus method

### DIFF
--- a/test/testnet/single/AccountingEngine.t.sol
+++ b/test/testnet/single/AccountingEngine.t.sol
@@ -217,7 +217,7 @@ contract SingleAccountingEngineTest is DSTest {
     _popDebtFromQueue(200 ether);
     safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(100 ether));
 
-    assertTrue(can_auction_debt());
+    assertTrue(!can_auction_debt());
   }
 
   function testFail_pop_debt_after_being_popped() public {
@@ -238,62 +238,15 @@ contract SingleAccountingEngineTest is DSTest {
   }
 
   function test_surplus_auction() public {
+    accountingEngine.modifyParameters('extraSurplusReceiver', abi.encode(address(0x123)));
     safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(100 ether));
     assertTrue(can_auctionSurplus());
-  }
-
-  function test_transfer_surplus_when_not_permitted() public {
-    accountingEngine.modifyParameters('extraSurplusReceiver', abi.encode(1));
-    accountingEngine.modifyParameters('surplusAmount', abi.encode(uint256(100 ether)));
-    safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(100 ether));
-    assertTrue(!can_auctionSurplus());
   }
 
   function test_transfer_surplus_when_receiver_not_defined() public {
     accountingEngine.modifyParameters('surplusTransferPercentage', abi.encode(uint256(1)));
     accountingEngine.modifyParameters('surplusAmount', abi.encode(uint256(100 ether)));
     safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(100 ether));
-    assertTrue(!can_auctionSurplus());
-  }
-
-  function test_transfer_surplus_when_amount_not_defined() public {
-    accountingEngine.modifyParameters('surplusTransferPercentage', abi.encode(1));
-    accountingEngine.modifyParameters('extraSurplusReceiver', abi.encode(1));
-    safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(100 ether));
-    assertTrue(!can_auctionSurplus());
-  }
-
-  function test_surplus_transfer() public {
-    accountingEngine.modifyParameters('surplusTransferPercentage', abi.encode(1));
-    accountingEngine.modifyParameters('extraSurplusReceiver', abi.encode(1));
-    accountingEngine.modifyParameters('surplusAmount', abi.encode(100 ether));
-    safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(100 ether));
-    assertTrue(!can_auctionSurplus());
-    assertTrue(can_auctionSurplus());
-  }
-
-  function test_surplus_transfer_twice_in_a_row() public {
-    accountingEngine.modifyParameters('surplusTransferPercentage', abi.encode(1));
-    accountingEngine.modifyParameters('extraSurplusReceiver', abi.encode(1));
-    accountingEngine.modifyParameters('surplusAmount', abi.encode(100 ether));
-    safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(200 ether));
-    accountingEngine.auctionSurplus();
-    assertEq(safeEngine.coinBalance(address(1)), 100 ether);
-    assertTrue(can_auctionSurplus());
-    accountingEngine.auctionSurplus();
-    assertEq(safeEngine.coinBalance(address(1)), 200 ether);
-  }
-
-  function test_surplus_transfer_after_waiting() public {
-    accountingEngine.modifyParameters('surplusTransferPercentage', abi.encode(1));
-    accountingEngine.modifyParameters('extraSurplusReceiver', abi.encode(1));
-    accountingEngine.modifyParameters('surplusAmount', abi.encode(100 ether));
-    accountingEngine.modifyParameters('surplusDelay', abi.encode(1));
-    safeEngine.createUnbackedDebt(address(0), address(accountingEngine), rad(200 ether));
-    assertTrue(!can_auctionSurplus());
-    hevm.warp(block.timestamp + 1);
-    accountingEngine.auctionSurplus();
-    assertEq(safeEngine.coinBalance(address(1)), 100 ether);
     assertTrue(!can_auctionSurplus());
   }
 


### PR DESCRIPTION
Closes #303 

Removed all tests specifically tied to the deprecated method `transferExtraSurplus` as that method no longer exists.  Fixed the other two tests which were impacted by the change from `transferExtraSurplus` to `extraSurplusReceiver` and surplus splitting.

Recommend adding additional tests for the changed functionality and new revert statements.