### PR TITLE
NFTPool Handler

### DIFF
--- a/src/contracts/for-test/NFTPool/NFTPool.sol
+++ b/src/contracts/for-test/NFTPool/NFTPool.sol
@@ -1,0 +1,1142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/utils/math/SafeMath.sol';
+import '@openzeppelin/token/ERC20/utils/SafeERC20.sol';
+import '@openzeppelin/token/ERC721/ERC721.sol';
+import '@openzeppelin/utils/Counters.sol';
+import '@openzeppelin/security/ReentrancyGuard.sol';
+import '@openzeppelin/utils/structs/EnumerableSet.sol';
+
+import './interfaces/INFTHandler.sol';
+import './interfaces/ICamelotMaster.sol';
+import './interfaces/INFTPool.sol';
+import './interfaces/IYieldBooster.sol';
+import './interfaces/tokens/IXGrailToken.sol';
+
+/*
+ * This contract wraps ERC20 assets into non-fungible staking positions called spNFTs
+ * spNFTs add the possibility to create an additional layer on liquidity providing lock features
+ * spNFTs are yield-generating positions when the NFTPool contract has allocations from the Camelot Master
+ */
+contract NFTPool is ReentrancyGuard, INFTPool, ERC721('Camelot staking position NFT', 'spNFT') {
+  using Address for address;
+  using Counters for Counters.Counter;
+  using EnumerableSet for EnumerableSet.AddressSet;
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  // Info of each NFT (staked position).
+  struct StakingPosition {
+    uint256 amount; // How many lp tokens the user has provided
+    uint256 amountWithMultiplier; // Amount + lock bonus faked amount (amount + amount*multiplier)
+    uint256 startLockTime; // The time at which the user made his deposit
+    uint256 lockDuration; // The lock duration in seconds
+    uint256 lockMultiplier; // Active lock multiplier (times 1e2)
+    uint256 rewardDebt; // Reward debt
+    uint256 boostPoints; // Allocated xGRAIL from yieldboost contract (optional)
+    uint256 totalMultiplier; // lockMultiplier + allocated xGRAIL boostPoints multiplier
+    uint256 pendingXGrailRewards; // Not harvested xGrail rewards
+    uint256 pendingGrailRewards; // Not harvested Grail rewards
+  }
+
+  Counters.Counter private _tokenIds;
+
+  EnumerableSet.AddressSet private _unlockOperators; // Addresses allowed to forcibly unlock locked spNFTs
+  address public operator; // Used to delegate multiplier settings to project's owners
+  ICamelotMaster public master; // Address of the master
+  address public immutable factory; // NFTPoolFactory contract's address
+  bool public initialized;
+
+  IERC20 private _lpToken; // Deposit token contract's address
+  IERC20 private _grailToken; // GrailToken contract's address
+  IXGrailToken private _xGrailToken; // XGrailToken contract's address
+  uint256 private _lpSupply; // Sum of deposit tokens on this pool
+  uint256 private _lpSupplyWithMultiplier; // Sum of deposit token on this pool including the user's total multiplier (lockMultiplier + boostPoints)
+  uint256 private _accRewardsPerShare; // Accumulated Rewards (staked token) per share, times 1e18. See below
+
+  // readable via getMultiplierSettings
+  uint256 public constant MAX_GLOBAL_MULTIPLIER_LIMIT = 25_000; // 250%, high limit for maxGlobalMultiplier (100 = 1%)
+  uint256 public constant MAX_LOCK_MULTIPLIER_LIMIT = 15_000; // 150%, high limit for maxLockMultiplier (100 = 1%)
+  uint256 public constant MAX_BOOST_MULTIPLIER_LIMIT = 15_000; // 150%, high limit for maxBoostMultiplier (100 = 1%)
+  uint256 private _maxGlobalMultiplier = 20_000; // 200%
+  uint256 private _maxLockDuration = 183 days; // 6 months, Capped lock duration to have the maximum bonus lockMultiplier
+  uint256 private _maxLockMultiplier = 10_000; // 100%, Max available lockMultiplier (100 = 1%)
+  uint256 private _maxBoostMultiplier = 10_000; // 100%, Max boost that can be earned from xGrail yieldBooster
+
+  uint256 private constant _TOTAL_REWARDS_SHARES = 10_000; // 100%, high limit for xGrailRewardsShare
+  uint256 public xGrailRewardsShare = 8000; // 80%, directly defines grailShare with the remaining value to 100%
+
+  bool public emergencyUnlock; // Release all locks in case of emergency
+
+  // readable via getStakingPosition
+  mapping(uint256 => StakingPosition) internal _stakingPositions; // Info of each NFT position that stakes LP tokens
+
+  constructor() {
+    factory = msg.sender;
+  }
+
+  function initialize(ICamelotMaster master_, IERC20 grailToken, IXGrailToken xGrailToken, IERC20 lpToken) external {
+    require(msg.sender == factory && !initialized, 'FORBIDDEN');
+    _lpToken = lpToken;
+    master = master_;
+    _grailToken = grailToken;
+    _xGrailToken = xGrailToken;
+    initialized = true;
+
+    // to convert GRAIL to xGRAIL
+    //_grailToken.approve(address(_xGrailToken), type(uint256).max);
+  }
+
+  /**
+   *
+   */
+  /**
+   * EVENTS *****************
+   */
+  /**
+   *
+   */
+  event AddToPosition(uint256 indexed tokenId, address user, uint256 amount);
+  event CreatePosition(uint256 indexed tokenId, uint256 amount, uint256 lockDuration);
+  event WithdrawFromPosition(uint256 indexed tokenId, uint256 amount);
+  event EmergencyWithdraw(uint256 indexed tokenId, uint256 amount);
+  event LockPosition(uint256 indexed tokenId, uint256 lockDuration);
+  event SplitPosition(uint256 indexed tokenId, uint256 splitAmount, uint256 newTokenId);
+  event MergePositions(address indexed user, uint256[] tokenIds);
+  event HarvestPosition(uint256 indexed tokenId, address to, uint256 pending);
+  event SetBoost(uint256 indexed tokenId, uint256 boostPoints);
+
+  event PoolUpdated(uint256 lastRewardTime, uint256 accRewardsPerShare);
+
+  event SetLockMultiplierSettings(uint256 maxLockDuration, uint256 maxLockMultiplier);
+  event SetBoostMultiplierSettings(uint256 maxGlobalMultiplier, uint256 maxBoostMultiplier);
+  event SetXGrailRewardsShare(uint256 xGrailRewardsShare);
+  event SetUnlockOperator(address operator, bool isAdded);
+  event SetEmergencyUnlock(bool emergencyUnlock);
+  event SetOperator(address operator);
+
+  /**
+   *
+   */
+  /**
+   * MODIFIERS *****************
+   */
+  /**
+   *
+   */
+
+  /**
+   * @dev Check if caller has operator rights
+   */
+  function _requireOnlyOwner() internal view {
+    require(msg.sender == owner(), 'FORBIDDEN');
+    // onlyOwner: caller is not the owner
+  }
+
+  /**
+   * @dev Check if caller is a validated YieldBooster contract
+   */
+  function _requireOnlyYieldBooster() internal view {
+    // onlyYieldBooster: caller has no yield boost rights
+    require(msg.sender == yieldBooster(), 'FORBIDDEN');
+  }
+
+  /**
+   * @dev Check if a userAddress has privileged rights on a spNFT
+   */
+  function _requireOnlyOperatorOrOwnerOf(uint256 tokenId) internal view {
+    // isApprovedOrOwner: caller has no rights on token
+    require(ERC721._isApprovedOrOwner(msg.sender, tokenId), 'FORBIDDEN');
+  }
+
+  /**
+   * @dev Check if a userAddress has privileged rights on a spNFT
+   */
+  function _requireOnlyApprovedOrOwnerOf(uint256 tokenId) internal view {
+    require(_exists(tokenId), 'ERC721: operator query for nonexistent token');
+    require(_isOwnerOf(msg.sender, tokenId) || getApproved(tokenId) == msg.sender, 'FORBIDDEN');
+  }
+
+  /**
+   * @dev Check if a msg.sender is owner of a spNFT
+   */
+  function _requireOnlyOwnerOf(uint256 tokenId) internal view {
+    require(_exists(tokenId), 'ERC721: operator query for nonexistent token');
+    // onlyOwnerOf: caller has no rights on token
+    require(_isOwnerOf(msg.sender, tokenId), 'not owner');
+  }
+
+  /**
+   *
+   */
+  /**
+   * PUBLIC VIEWS *****************
+   */
+  /**
+   *
+   */
+
+  /**
+   * @dev Returns this contract's owner (= master contract's owner)
+   */
+  function owner() public view returns (address) {
+    return master.owner();
+  }
+
+  /**
+   * @dev Returns the number of unlockOperators
+   */
+  function unlockOperatorsLength() external view returns (uint256) {
+    return _unlockOperators.length();
+  }
+
+  /**
+   * @dev Returns an unlockOperator from its "index"
+   */
+  function unlockOperator(uint256 index) external view returns (address) {
+    if (_unlockOperators.length() <= index) return address(0);
+    return _unlockOperators.at(index);
+  }
+
+  /**
+   * @dev Returns true if "_operator" address is an unlockOperator
+   */
+  function isUnlockOperator(address _operator) external view returns (bool) {
+    return _unlockOperators.contains(_operator);
+  }
+
+  /**
+   * @dev Get master-defined yield booster contract address
+   */
+  function yieldBooster() public view returns (address) {
+    return master.yieldBooster();
+  }
+
+  /**
+   * @dev Returns true if "tokenId" is an existing spNFT id
+   */
+  function exists(uint256 tokenId) external view override returns (bool) {
+    return ERC721._exists(tokenId);
+  }
+
+  /**
+   * @dev Returns last minted NFT id
+   */
+  function lastTokenId() external view returns (uint256) {
+    return _tokenIds.current();
+  }
+
+  /**
+   * @dev Returns true if emergency unlocks are activated on this pool or on the master
+   */
+  function isUnlocked() public view returns (bool) {
+    return emergencyUnlock || master.emergencyUnlock();
+  }
+
+  /**
+   * @dev Returns true if this pool currently has deposits
+   */
+  function hasDeposits() external view override returns (bool) {
+    return _lpSupplyWithMultiplier > 0;
+  }
+
+  /**
+   * @dev Returns general "pool" info for this contract
+   */
+  function getPoolInfo()
+    external
+    view
+    override
+    returns (
+      address lpToken,
+      address grailToken,
+      address xGrailToken,
+      uint256 lastRewardTime,
+      uint256 accRewardsPerShare,
+      uint256 lpSupply,
+      uint256 lpSupplyWithMultiplier,
+      uint256 allocPoint
+    )
+  {
+    (, allocPoint, lastRewardTime,,) = master.getPoolInfo(address(this));
+    return (
+      address(_lpToken),
+      address(_grailToken),
+      address(_xGrailToken),
+      lastRewardTime,
+      _accRewardsPerShare,
+      _lpSupply,
+      _lpSupplyWithMultiplier,
+      allocPoint
+    );
+  }
+
+  /**
+   * @dev Returns all multiplier settings for this contract
+   */
+  function getMultiplierSettings()
+    external
+    view
+    returns (
+      uint256 maxGlobalMultiplier,
+      uint256 maxLockDuration,
+      uint256 maxLockMultiplier,
+      uint256 maxBoostMultiplier
+    )
+  {
+    return (_maxGlobalMultiplier, _maxLockDuration, _maxLockMultiplier, _maxBoostMultiplier);
+  }
+
+  /**
+   * @dev Returns bonus multiplier from YieldBooster contract for given "amount" (LP token staked) and "boostPoints" (result is *1e4)
+   */
+  function getMultiplierByBoostPoints(uint256 amount, uint256 boostPoints) public view returns (uint256) {
+    if (boostPoints == 0 || amount == 0) return 0;
+
+    address yieldBoosterAddress = yieldBooster();
+    // only call yieldBooster contract if defined on master
+    return yieldBoosterAddress != address(0)
+      ? IYieldBooster(yieldBoosterAddress).getMultiplier(
+        address(this), _maxBoostMultiplier, amount, _lpSupply, boostPoints
+      )
+      : 0;
+  }
+
+  /**
+   * @dev Returns expected multiplier for a "lockDuration" duration lock (result is *1e4)
+   */
+  function getMultiplierByLockDuration(uint256 lockDuration) public view returns (uint256) {
+    // in case of emergency unlock
+    if (isUnlocked()) return 0;
+
+    if (_maxLockDuration == 0 || lockDuration == 0) return 0;
+
+    // capped to maxLockDuration
+    if (lockDuration >= _maxLockDuration) return _maxLockMultiplier;
+
+    return _maxLockMultiplier.mul(lockDuration).div(_maxLockDuration);
+  }
+
+  /**
+   * @dev Returns a position info
+   */
+  function getStakingPosition(uint256 tokenId)
+    external
+    view
+    override
+    returns (
+      uint256 amount,
+      uint256 amountWithMultiplier,
+      uint256 startLockTime,
+      uint256 lockDuration,
+      uint256 lockMultiplier,
+      uint256 rewardDebt,
+      uint256 boostPoints,
+      uint256 totalMultiplier
+    )
+  {
+    StakingPosition storage position = _stakingPositions[tokenId];
+    return (
+      position.amount,
+      position.amountWithMultiplier,
+      position.startLockTime,
+      position.lockDuration,
+      position.lockMultiplier,
+      position.rewardDebt,
+      position.boostPoints,
+      position.totalMultiplier
+    );
+  }
+
+  /**
+   * @dev Returns pending rewards for a position
+   */
+  function pendingRewards(uint256 tokenId) external view returns (uint256) {
+    StakingPosition storage position = _stakingPositions[tokenId];
+
+    uint256 accRewardsPerShare = _accRewardsPerShare;
+    (,, uint256 lastRewardTime, uint256 reserve, uint256 poolEmissionRate) = master.getPoolInfo(address(this));
+
+    // recompute accRewardsPerShare if not up to date
+    if ((reserve > 0 || _currentBlockTimestamp() > lastRewardTime) && _lpSupplyWithMultiplier > 0) {
+      uint256 duration = _currentBlockTimestamp().sub(lastRewardTime);
+      // adding reserve here in case master has been synced but not the pool
+      uint256 tokenRewards = duration.mul(poolEmissionRate).add(reserve);
+      accRewardsPerShare = accRewardsPerShare.add(tokenRewards.mul(1e18).div(_lpSupplyWithMultiplier));
+    }
+
+    return position.amountWithMultiplier.mul(accRewardsPerShare).div(1e18).sub(position.rewardDebt).add(
+      position.pendingXGrailRewards
+    ).add(position.pendingGrailRewards);
+  }
+
+  /**
+   *
+   */
+  /**
+   * OWNABLE FUNCTIONS *****************
+   */
+  /**
+   *
+   */
+
+  /**
+   * @dev Set lock multiplier settings
+   *
+   * maxLockMultiplier must be <= MAX_LOCK_MULTIPLIER_LIMIT
+   * maxLockMultiplier must be <= _maxGlobalMultiplier - _maxBoostMultiplier
+   *
+   * Must only be called by the owner
+   */
+  function setLockMultiplierSettings(uint256 maxLockDuration, uint256 maxLockMultiplier) external {
+    require(msg.sender == owner() || msg.sender == operator, 'FORBIDDEN');
+    // onlyOperatorOrOwner: caller has no operator rights
+    require(
+      maxLockMultiplier <= MAX_LOCK_MULTIPLIER_LIMIT
+        && maxLockMultiplier.add(_maxBoostMultiplier) <= _maxGlobalMultiplier,
+      'too high'
+    );
+    // setLockSettings: maxGlobalMultiplier is too high
+    _maxLockDuration = maxLockDuration;
+    _maxLockMultiplier = maxLockMultiplier;
+
+    emit SetLockMultiplierSettings(maxLockDuration, maxLockMultiplier);
+  }
+
+  /**
+   * @dev Set global and boost multiplier settings
+   *
+   * maxGlobalMultiplier must be <= MAX_GLOBAL_MULTIPLIER_LIMIT
+   * maxBoostMultiplier must be <= MAX_BOOST_MULTIPLIER_LIMIT
+   * (maxBoostMultiplier + _maxLockMultiplier) must be <= _maxGlobalMultiplier
+   *
+   * Must only be called by the owner
+   */
+  function setBoostMultiplierSettings(uint256 maxGlobalMultiplier, uint256 maxBoostMultiplier) external {
+    _requireOnlyOwner();
+    require(maxGlobalMultiplier <= MAX_GLOBAL_MULTIPLIER_LIMIT, 'too high');
+
+    // setMultiplierSettings: maxGlobalMultiplier is too high
+    require(
+      maxBoostMultiplier <= MAX_BOOST_MULTIPLIER_LIMIT
+        && maxBoostMultiplier.add(_maxLockMultiplier) <= maxGlobalMultiplier,
+      'too high'
+    );
+    // setLockSettings: maxGlobalMultiplier is too high
+    _maxGlobalMultiplier = maxGlobalMultiplier;
+    _maxBoostMultiplier = maxBoostMultiplier;
+
+    emit SetBoostMultiplierSettings(maxGlobalMultiplier, maxBoostMultiplier);
+  }
+
+  /**
+   * @dev Set the share of xGRAIL for the distributed rewards
+   * The share of GRAIL will incidently be 100% - xGrailRewardsShare
+   *
+   * Must only be called by the owner
+   */
+  function setXGrailRewardsShare(uint256 xGrailRewardsShare_) external {
+    _requireOnlyOwner();
+    require(xGrailRewardsShare_ <= _TOTAL_REWARDS_SHARES, 'too high');
+
+    xGrailRewardsShare = xGrailRewardsShare_;
+    emit SetXGrailRewardsShare(xGrailRewardsShare_);
+  }
+
+  /**
+   * @dev Add or remove unlock operators
+   *
+   * Must only be called by the owner
+   */
+  function setUnlockOperator(address _operator, bool add) external {
+    _requireOnlyOwner();
+
+    if (add) {
+      _unlockOperators.add(_operator);
+    } else {
+      _unlockOperators.remove(_operator);
+    }
+    emit SetUnlockOperator(_operator, add);
+  }
+
+  /**
+   * @dev Set emergency unlock status
+   *
+   * Must only be called by the owner
+   */
+  function setEmergencyUnlock(bool emergencyUnlock_) external {
+    _requireOnlyOwner();
+
+    emergencyUnlock = emergencyUnlock_;
+    emit SetEmergencyUnlock(emergencyUnlock);
+  }
+
+  /**
+   * @dev Set operator (usually deposit token's project's owner) to adjust contract's settings
+   *
+   * Must only be called by the owner
+   */
+  function setOperator(address operator_) external {
+    _requireOnlyOwner();
+
+    operator = operator_;
+    emit SetOperator(operator_);
+  }
+
+  /**
+   *
+   */
+  /**
+   * EXTERNAL PUBLIC FUNCTIONS  *****************
+   */
+  /**
+   *
+   */
+
+  /**
+   * @dev Add nonReentrant to ERC721.transferFrom
+   */
+  function transferFrom(address from, address to, uint256 tokenId) public override(ERC721, IERC721) nonReentrant {
+    ERC721.transferFrom(from, to, tokenId);
+  }
+
+  /**
+   * @dev Add nonReentrant to ERC721.safeTransferFrom
+   */
+  function safeTransferFrom(
+    address from,
+    address to,
+    uint256 tokenId,
+    bytes memory _data
+  ) public override(ERC721, IERC721) nonReentrant {
+    ERC721.safeTransferFrom(from, to, tokenId, _data);
+  }
+
+  /**
+   * @dev Updates rewards states of the given pool to be up-to-date
+   */
+  function updatePool() external nonReentrant {
+    _updatePool();
+  }
+
+  /**
+   * @dev Create a staking position (spNFT) with an optional lockDuration
+   */
+  function createPosition(uint256 amount, uint256 lockDuration) external nonReentrant {
+    // no new lock can be set if the pool has been unlocked
+    if (isUnlocked()) {
+      require(lockDuration == 0, 'locks disabled');
+    }
+
+    _updatePool();
+
+    // handle tokens with transfer tax
+    amount = _transferSupportingFeeOnTransfer(_lpToken, msg.sender, amount);
+    require(amount != 0, 'zero amount'); // createPosition: amount cannot be null
+
+    // mint NFT position token
+    uint256 currentTokenId = _mintNextTokenId(msg.sender);
+
+    // calculate bonuses
+    uint256 lockMultiplier = getMultiplierByLockDuration(lockDuration);
+    uint256 amountWithMultiplier = amount.mul(lockMultiplier.add(1e4)).div(1e4);
+
+    // create position
+    _stakingPositions[currentTokenId] = StakingPosition({
+      amount: amount,
+      rewardDebt: amountWithMultiplier.mul(_accRewardsPerShare).div(1e18),
+      lockDuration: lockDuration,
+      startLockTime: _currentBlockTimestamp(),
+      lockMultiplier: lockMultiplier,
+      amountWithMultiplier: amountWithMultiplier,
+      boostPoints: 0,
+      totalMultiplier: lockMultiplier,
+      pendingGrailRewards: 0,
+      pendingXGrailRewards: 0
+    });
+
+    // update total lp supply
+    _lpSupply = _lpSupply.add(amount);
+    _lpSupplyWithMultiplier = _lpSupplyWithMultiplier.add(amountWithMultiplier);
+
+    emit CreatePosition(currentTokenId, amount, lockDuration);
+  }
+
+  /**
+   * @dev Add to an existing staking position
+   *
+   * Can only be called by spNFT's owner or operators
+   */
+  function addToPosition(uint256 tokenId, uint256 amountToAdd) external nonReentrant {
+    _requireOnlyOperatorOrOwnerOf(tokenId);
+    require(amountToAdd > 0, '0 amount'); // addToPosition: amount cannot be null
+
+    _updatePool();
+    address nftOwner = ERC721.ownerOf(tokenId);
+    _harvestPosition(tokenId, nftOwner);
+
+    StakingPosition storage position = _stakingPositions[tokenId];
+
+    // if position is locked, renew the lock
+    if (position.lockDuration > 0) {
+      position.startLockTime = _currentBlockTimestamp();
+      position.lockMultiplier = getMultiplierByLockDuration(position.lockDuration);
+    }
+
+    // handle tokens with transfer tax
+    amountToAdd = _transferSupportingFeeOnTransfer(_lpToken, msg.sender, amountToAdd);
+
+    // update position
+    position.amount = position.amount.add(amountToAdd);
+    _lpSupply = _lpSupply.add(amountToAdd);
+    _updateBoostMultiplierInfoAndRewardDebt(position);
+
+    _checkOnAddToPosition(nftOwner, tokenId, amountToAdd);
+    emit AddToPosition(tokenId, msg.sender, amountToAdd);
+  }
+
+  /**
+   * @dev Assign "amount" of boost points to a position
+   *
+   * Can only be called by the master-defined YieldBooster contract
+   */
+  function boost(uint256 tokenId, uint256 amount) external override nonReentrant {
+    _requireOnlyYieldBooster();
+    require(ERC721._exists(tokenId), 'invalid tokenId');
+
+    _updatePool();
+    _harvestPosition(tokenId, address(0));
+
+    StakingPosition storage position = _stakingPositions[tokenId];
+
+    // update position
+    uint256 boostPoints = position.boostPoints.add(amount);
+    position.boostPoints = boostPoints;
+    _updateBoostMultiplierInfoAndRewardDebt(position);
+    emit SetBoost(tokenId, boostPoints);
+  }
+
+  /**
+   * @dev Remove "amount" of boost points from a position
+   *
+   * Can only be called by the master-defined YieldBooster contract
+   */
+  function unboost(uint256 tokenId, uint256 amount) external override nonReentrant {
+    _requireOnlyYieldBooster();
+
+    _updatePool();
+    _harvestPosition(tokenId, address(0));
+
+    StakingPosition storage position = _stakingPositions[tokenId];
+
+    // update position
+    uint256 boostPoints = position.boostPoints.sub(amount);
+    position.boostPoints = boostPoints;
+    _updateBoostMultiplierInfoAndRewardDebt(position);
+    emit SetBoost(tokenId, boostPoints);
+  }
+
+  /**
+   * @dev Harvest from a staking position
+   *
+   * Can only be called by spNFT's owner or approved address
+   */
+  function harvestPosition(uint256 tokenId) external nonReentrant {
+    _requireOnlyApprovedOrOwnerOf(tokenId);
+
+    _updatePool();
+    _harvestPosition(tokenId, ERC721.ownerOf(tokenId));
+    _updateBoostMultiplierInfoAndRewardDebt(_stakingPositions[tokenId]);
+  }
+
+  /**
+   * @dev Harvest from a staking position to "to" address
+   *
+   * Can only be called by spNFT's owner or approved address
+   * spNFT's owner must be a contract
+   */
+  function harvestPositionTo(uint256 tokenId, address to) external nonReentrant {
+    _requireOnlyApprovedOrOwnerOf(tokenId);
+    require(ERC721.ownerOf(tokenId).isContract(), 'FORBIDDEN');
+
+    _updatePool();
+    _harvestPosition(tokenId, to);
+    _updateBoostMultiplierInfoAndRewardDebt(_stakingPositions[tokenId]);
+  }
+
+  /**
+   * @dev Harvest from multiple staking positions to "to" address
+   *
+   * Can only be called by spNFT's owner or approved address
+   */
+  function harvestPositionsTo(uint256[] calldata tokenIds, address to) external nonReentrant {
+    _updatePool();
+
+    uint256 length = tokenIds.length;
+
+    for (uint256 i = 0; i < length; ++i) {
+      uint256 tokenId = tokenIds[i];
+      _requireOnlyApprovedOrOwnerOf(tokenId);
+      address tokenOwner = ERC721.ownerOf(tokenId);
+      // if sender is the current owner, must also be the harvest dst address
+      // if sender is approved, current owner must be a contract
+      require((msg.sender == tokenOwner && msg.sender == to) || tokenOwner.isContract(), 'FORBIDDEN');
+
+      _harvestPosition(tokenId, to);
+      _updateBoostMultiplierInfoAndRewardDebt(_stakingPositions[tokenId]);
+    }
+  }
+
+  /**
+   * @dev Withdraw from a staking position
+   *
+   * Can only be called by spNFT's owner or approved address
+   */
+  function withdrawFromPosition(uint256 tokenId, uint256 amountToWithdraw) external nonReentrant {
+    _requireOnlyApprovedOrOwnerOf(tokenId);
+
+    _updatePool();
+    address nftOwner = ERC721.ownerOf(tokenId);
+    _withdrawFromPosition(nftOwner, tokenId, amountToWithdraw);
+    _checkOnWithdraw(nftOwner, tokenId, amountToWithdraw);
+  }
+
+  /**
+   * @dev Renew lock from a staking position
+   *
+   * Can only be called by spNFT's owner or approved address
+   */
+  function renewLockPosition(uint256 tokenId) external nonReentrant {
+    _requireOnlyApprovedOrOwnerOf(tokenId);
+
+    _updatePool();
+    _lockPosition(tokenId, _stakingPositions[tokenId].lockDuration);
+  }
+
+  /**
+   * @dev Lock a staking position (can be used to extend a lock)
+   *
+   * Can only be called by spNFT's owner or approved address
+   */
+  function lockPosition(uint256 tokenId, uint256 lockDuration) external nonReentrant {
+    _requireOnlyApprovedOrOwnerOf(tokenId);
+
+    _updatePool();
+    _lockPosition(tokenId, lockDuration);
+  }
+
+  /**
+   * @dev Split a staking position into two
+   *
+   * Can only be called by nft's owner
+   */
+  function splitPosition(uint256 tokenId, uint256 splitAmount) external nonReentrant {
+    _requireOnlyOwnerOf(tokenId);
+
+    _updatePool();
+    _harvestPosition(tokenId, ERC721.ownerOf(tokenId));
+
+    StakingPosition storage position = _stakingPositions[tokenId];
+    // can't have the original token completely emptied
+    require(splitAmount < position.amount, 'invalid splitAmount');
+
+    // sub from existing position
+    position.amount = position.amount.sub(splitAmount);
+    _updateBoostMultiplierInfoAndRewardDebt(position);
+
+    // create new position
+    uint256 currentTokenId = _mintNextTokenId(msg.sender);
+    uint256 lockDuration = position.lockDuration;
+    uint256 lockMultiplier = position.lockMultiplier;
+    uint256 amountWithMultiplier = splitAmount.mul(lockMultiplier.add(1e4)).div(1e4);
+    _stakingPositions[currentTokenId] = StakingPosition({
+      amount: splitAmount,
+      rewardDebt: amountWithMultiplier.mul(_accRewardsPerShare).div(1e18),
+      lockDuration: lockDuration,
+      startLockTime: position.startLockTime,
+      lockMultiplier: lockMultiplier,
+      amountWithMultiplier: amountWithMultiplier,
+      boostPoints: 0,
+      totalMultiplier: lockMultiplier,
+      pendingGrailRewards: 0,
+      pendingXGrailRewards: 0
+    });
+
+    _lpSupplyWithMultiplier = _lpSupplyWithMultiplier.add(amountWithMultiplier);
+
+    emit SplitPosition(tokenId, splitAmount, currentTokenId);
+  }
+
+  /**
+   * @dev Merge an array of staking positions into a single one with "lockDuration"
+   * Can't be used on positions with a higher lock duration than "lockDuration" param
+   *
+   * Can only be called by spNFT's owner
+   */
+  function mergePositions(uint256[] calldata tokenIds, uint256 lockDuration) external nonReentrant {
+    _updatePool();
+
+    uint256 length = tokenIds.length;
+    require(length > 1, 'invalid');
+    // mergePositions: array must have at least two items
+
+    // set the destination position into which the others will be merged (using first item of the list)
+    uint256 dstTokenId = tokenIds[0];
+    _requireOnlyOwnerOf(dstTokenId);
+
+    StakingPosition storage dstPosition = _stakingPositions[dstTokenId];
+    require(dstPosition.lockDuration <= lockDuration, "can't merge");
+    _harvestPosition(dstTokenId, msg.sender);
+
+    dstPosition.lockDuration = lockDuration;
+    dstPosition.lockMultiplier = getMultiplierByLockDuration(lockDuration);
+
+    // loop starts at 2nd element
+    for (uint256 i = 1; i < length; ++i) {
+      uint256 tokenId = tokenIds[i];
+      _requireOnlyOwnerOf(tokenId);
+      require(tokenId != dstTokenId, 'invalid token id');
+
+      _harvestPosition(tokenId, msg.sender);
+      StakingPosition storage position = _stakingPositions[tokenId];
+
+      // positions must have a lower lock duration than param
+      require(position.lockDuration <= lockDuration, "can't merge");
+      // mergePositions: positions cannot be merged
+
+      // we want to use the latest startLockTime
+      if (dstPosition.startLockTime < position.startLockTime) {
+        dstPosition.startLockTime = position.startLockTime;
+      }
+
+      // aggregate amounts to the destination position
+      dstPosition.amount = dstPosition.amount.add(position.amount);
+
+      // destroy position
+      _lpSupplyWithMultiplier = _lpSupplyWithMultiplier.sub(position.amountWithMultiplier);
+      _destroyPosition(tokenId, position.boostPoints);
+    }
+
+    _updateBoostMultiplierInfoAndRewardDebt(dstPosition);
+    emit MergePositions(msg.sender, tokenIds);
+  }
+
+  /**
+   * Withdraw without caring about rewards, EMERGENCY ONLY
+   *
+   * Can only be called by spNFT's owner
+   */
+  function emergencyWithdraw(uint256 tokenId) external nonReentrant {
+    _requireOnlyOwnerOf(tokenId);
+
+    StakingPosition storage position = _stakingPositions[tokenId];
+
+    // position should be unlocked
+    require(
+      _unlockOperators.contains(msg.sender)
+        || position.startLockTime.add(position.lockDuration) <= _currentBlockTimestamp() || isUnlocked(),
+      'locked'
+    );
+    // emergencyWithdraw: locked
+
+    uint256 amount = position.amount;
+
+    // update total lp supply
+    _lpSupply = _lpSupply.sub(amount);
+    _lpSupplyWithMultiplier = _lpSupplyWithMultiplier.sub(position.amountWithMultiplier);
+
+    // destroy position (ignore boost points)
+    _destroyPosition(tokenId, 0);
+
+    emit EmergencyWithdraw(tokenId, amount);
+    _lpToken.safeTransfer(msg.sender, amount);
+  }
+
+  /**
+   *
+   */
+  /**
+   * INTERNAL FUNCTIONS *****************
+   */
+  /**
+   *
+   */
+
+  /**
+   * @dev Returns whether "userAddress" is the owner of "tokenId" spNFT
+   */
+  function _isOwnerOf(address userAddress, uint256 tokenId) internal view returns (bool) {
+    return userAddress == ERC721.ownerOf(tokenId);
+  }
+
+  /**
+   * @dev Updates rewards states of this pool to be up-to-date
+   */
+  function _updatePool() internal {
+    // gets allocated rewards from Master and updates
+    (uint256 rewards) = master.claimRewards();
+
+    if (rewards > 0) {
+      _accRewardsPerShare = _accRewardsPerShare.add(rewards.mul(1e18).div(_lpSupplyWithMultiplier));
+    }
+
+    emit PoolUpdated(_currentBlockTimestamp(), _accRewardsPerShare);
+  }
+
+  /**
+   * @dev Destroys spNFT
+   *
+   * "boostPointsToDeallocate" is set to 0 to ignore boost points handling if called during an emergencyWithdraw
+   * Users should still be able to deallocate xGRAIL from the YieldBooster contract
+   */
+  function _destroyPosition(uint256 tokenId, uint256 boostPoints) internal {
+    // calls yieldBooster contract to deallocate the spNFT's owner boost points if any
+    if (boostPoints > 0) {
+      IYieldBooster(yieldBooster()).deallocateAllFromPool(msg.sender, tokenId);
+    }
+
+    // burn spNFT
+    delete _stakingPositions[tokenId];
+    ERC721._burn(tokenId);
+  }
+
+  /**
+   * @dev Computes new tokenId and mint associated spNFT to "to" address
+   */
+  function _mintNextTokenId(address to) internal returns (uint256 tokenId) {
+    _tokenIds.increment();
+    tokenId = _tokenIds.current();
+    _safeMint(to, tokenId);
+  }
+
+  /**
+   * @dev Withdraw from a staking position and destroy it
+   *
+   * _updatePool() should be executed before calling this
+   */
+  function _withdrawFromPosition(address nftOwner, uint256 tokenId, uint256 amountToWithdraw) internal {
+    require(amountToWithdraw > 0, 'null');
+    // withdrawFromPosition: amount cannot be null
+
+    StakingPosition storage position = _stakingPositions[tokenId];
+    require(
+      _unlockOperators.contains(nftOwner)
+        || position.startLockTime.add(position.lockDuration) <= _currentBlockTimestamp() || isUnlocked(),
+      'locked'
+    );
+    // withdrawFromPosition: invalid amount
+    require(position.amount >= amountToWithdraw, 'invalid');
+
+    _harvestPosition(tokenId, nftOwner);
+
+    // update position
+    position.amount = position.amount.sub(amountToWithdraw);
+
+    // update total lp supply
+    _lpSupply = _lpSupply.sub(amountToWithdraw);
+
+    if (position.amount == 0) {
+      // destroy if now empty
+      _lpSupplyWithMultiplier = _lpSupplyWithMultiplier.sub(position.amountWithMultiplier);
+      _destroyPosition(tokenId, position.boostPoints);
+    } else {
+      _updateBoostMultiplierInfoAndRewardDebt(position);
+    }
+
+    emit WithdrawFromPosition(tokenId, amountToWithdraw);
+    _lpToken.safeTransfer(nftOwner, amountToWithdraw);
+  }
+
+  /**
+   * @dev updates position's boost multiplier, totalMultiplier, amountWithMultiplier (_lpSupplyWithMultiplier)
+   * and rewardDebt without updating lockMultiplier
+   */
+  function _updateBoostMultiplierInfoAndRewardDebt(StakingPosition storage position) internal {
+    // keep the original lock multiplier and recompute current boostPoints multiplier
+    uint256 newTotalMultiplier =
+      getMultiplierByBoostPoints(position.amount, position.boostPoints).add(position.lockMultiplier);
+    if (newTotalMultiplier > _maxGlobalMultiplier) newTotalMultiplier = _maxGlobalMultiplier;
+
+    position.totalMultiplier = newTotalMultiplier;
+    uint256 amountWithMultiplier = position.amount.mul(newTotalMultiplier.add(1e4)).div(1e4);
+    // update global supply
+    _lpSupplyWithMultiplier = _lpSupplyWithMultiplier.sub(position.amountWithMultiplier).add(amountWithMultiplier);
+    position.amountWithMultiplier = amountWithMultiplier;
+
+    position.rewardDebt = amountWithMultiplier.mul(_accRewardsPerShare).div(1e18);
+  }
+
+  /**
+   * @dev Harvest rewards from a position
+   * Will also update the position's totalMultiplier
+   */
+  function _harvestPosition(uint256 tokenId, address to) internal {
+    StakingPosition storage position = _stakingPositions[tokenId];
+
+    // compute position's pending rewards
+    uint256 pending = position.amountWithMultiplier.mul(_accRewardsPerShare).div(1e18).sub(position.rewardDebt);
+
+    // unlock the position if pool has been unlocked or position is unlocked
+    if (isUnlocked() || position.startLockTime.add(position.lockDuration) <= _currentBlockTimestamp()) {
+      position.lockDuration = 0;
+      position.lockMultiplier = 0;
+    }
+
+    // transfer rewards
+    if (pending > 0 || position.pendingXGrailRewards > 0 || position.pendingGrailRewards > 0) {
+      uint256 xGrailRewards = pending.mul(xGrailRewardsShare).div(_TOTAL_REWARDS_SHARES);
+      uint256 grailAmount = pending.add(position.pendingGrailRewards).sub(xGrailRewards);
+
+      xGrailRewards = xGrailRewards.add(position.pendingXGrailRewards);
+
+      // Stack rewards in a buffer if to is equal to address(0)
+      if (address(0) == to) {
+        position.pendingXGrailRewards = xGrailRewards;
+        position.pendingGrailRewards = grailAmount;
+      } else {
+        // convert and send xGRAIL + GRAIL rewards
+        position.pendingXGrailRewards = 0;
+        position.pendingGrailRewards = 0;
+
+        if (xGrailRewards > 0) xGrailRewards = _safeConvertTo(to, xGrailRewards);
+        // send share of GRAIL rewards
+        grailAmount = _safeRewardsTransfer(to, grailAmount);
+
+        // forbidden to harvest if contract has not explicitly confirmed it handle it
+        _checkOnNFTHarvest(to, tokenId, grailAmount, xGrailRewards);
+      }
+    }
+    emit HarvestPosition(tokenId, to, pending);
+  }
+
+  /**
+   * @dev Renew lock from a staking position with "lockDuration"
+   */
+  function _lockPosition(uint256 tokenId, uint256 lockDuration) internal {
+    require(!isUnlocked(), 'locks disabled');
+
+    StakingPosition storage position = _stakingPositions[tokenId];
+
+    // for renew only, check if new lockDuration is at least = to the remaining active duration
+    uint256 endTime = position.startLockTime.add(position.lockDuration);
+    uint256 currentBlockTimestamp = _currentBlockTimestamp();
+    if (endTime > currentBlockTimestamp) {
+      require(lockDuration >= endTime.sub(currentBlockTimestamp) && lockDuration > 0, 'invalid');
+    }
+
+    _harvestPosition(tokenId, msg.sender);
+
+    // update position and total lp supply
+    position.lockDuration = lockDuration;
+    position.lockMultiplier = getMultiplierByLockDuration(lockDuration);
+    position.startLockTime = currentBlockTimestamp;
+    _updateBoostMultiplierInfoAndRewardDebt(position);
+
+    emit LockPosition(tokenId, lockDuration);
+  }
+
+  /**
+   * @dev Handle deposits of tokens with transfer tax
+   */
+  function _transferSupportingFeeOnTransfer(
+    IERC20 token,
+    address user,
+    uint256 amount
+  ) internal returns (uint256 receivedAmount) {
+    uint256 previousBalance = token.balanceOf(address(this));
+    token.safeTransferFrom(user, address(this), amount);
+    return token.balanceOf(address(this)).sub(previousBalance);
+  }
+
+  /**
+   * @dev Safe token transfer function, in case rounding error causes pool to not have enough tokens
+   */
+  function _safeRewardsTransfer(address to, uint256 amount) internal returns (uint256) {
+    uint256 balance = _grailToken.balanceOf(address(this));
+    // cap to available balance
+    if (amount > balance) {
+      amount = balance;
+    }
+    _grailToken.safeTransfer(to, amount);
+    return amount;
+  }
+
+  /**
+   * @dev Safe convert GRAIL to xGRAIL function, in case rounding error causes pool to not have enough tokens
+   */
+  function _safeConvertTo(address to, uint256 amount) internal returns (uint256) {
+    uint256 balance = _grailToken.balanceOf(address(this));
+    // cap to available balance
+    if (amount > balance) {
+      amount = balance;
+    }
+    if (amount > 0) _xGrailToken.convertTo(amount, to);
+    return amount;
+  }
+
+  /**
+   * @dev If NFT's owner is a contract, confirm whether it's able to handle rewards harvesting
+   */
+  function _checkOnNFTHarvest(address to, uint256 tokenId, uint256 grailAmount, uint256 xGrailAmount) internal {
+    address nftOwner = ERC721.ownerOf(tokenId);
+    if (nftOwner.isContract()) {
+      bytes memory returndata = nftOwner.functionCall(
+        abi.encodeWithSelector(
+          INFTHandler(nftOwner).onNFTHarvest.selector, msg.sender, to, tokenId, grailAmount, xGrailAmount
+        ),
+        'non implemented'
+      );
+      require(abi.decode(returndata, (bool)), 'FORBIDDEN');
+    }
+  }
+
+  /**
+   * @dev If NFT's owner is a contract, confirm whether it's able to handle addToPosition
+   */
+  function _checkOnAddToPosition(address nftOwner, uint256 tokenId, uint256 lpAmount) internal {
+    if (nftOwner.isContract()) {
+      bytes memory returndata = nftOwner.functionCall(
+        abi.encodeWithSelector(INFTHandler(nftOwner).onNFTAddToPosition.selector, msg.sender, tokenId, lpAmount),
+        'non implemented'
+      );
+      require(abi.decode(returndata, (bool)), 'FORBIDDEN');
+    }
+  }
+
+  /**
+   * @dev If NFT's owner is a contract, confirm whether it's able to handle withdrawals
+   */
+  function _checkOnWithdraw(address nftOwner, uint256 tokenId, uint256 lpAmount) internal {
+    if (nftOwner.isContract()) {
+      bytes memory returndata = nftOwner.functionCall(
+        abi.encodeWithSelector(INFTHandler(nftOwner).onNFTWithdraw.selector, msg.sender, tokenId, lpAmount),
+        'non implemented'
+      );
+      require(abi.decode(returndata, (bool)), 'FORBIDDEN');
+    }
+  }
+
+  /**
+   * @dev Forbid transfer when spNFT's owner is a contract and an operator is trying to transfer it
+   * This is made to avoid unintended side effects
+   *
+   * Contract owner can still implement it by itself if needed
+   */
+  function _beforeTokenTransfer(
+    address from,
+    address, /*to*/
+    uint256, /*tokenId*/
+    uint256 /*btachsize*/
+  ) internal view override {
+    require(!from.isContract() || msg.sender == from, 'FORBIDDEN');
+  }
+
+  /**
+   * @dev Utility function to get the current block timestamp
+   */
+  function _currentBlockTimestamp() internal view virtual returns (uint256) {
+    /* solhint-disable not-rely-on-time */
+    return block.timestamp;
+  }
+}

--- a/src/contracts/for-test/NFTPool/interfaces/ICamelotMaster.sol
+++ b/src/contracts/for-test/NFTPool/interfaces/ICamelotMaster.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ICamelotMaster {
+  function grailToken() external view returns (address);
+  function yieldBooster() external view returns (address);
+  function owner() external view returns (address);
+  function emergencyUnlock() external view returns (bool);
+
+  function getPoolInfo(address _poolAddress)
+    external
+    view
+    returns (address poolAddress, uint256 allocPoint, uint256 lastRewardTime, uint256 reserve, uint256 poolEmissionRate);
+
+  function claimRewards() external returns (uint256);
+}

--- a/src/contracts/for-test/NFTPool/interfaces/INFTHandler.sol
+++ b/src/contracts/for-test/NFTPool/interfaces/INFTHandler.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/token/ERC721/IERC721Receiver.sol';
+
+interface INFTHandler is IERC721Receiver {
+  function onNFTHarvest(
+    address operator,
+    address to,
+    uint256 tokenId,
+    uint256 grailAmount,
+    uint256 xGrailAmount
+  ) external returns (bool);
+  function onNFTAddToPosition(address operator, uint256 tokenId, uint256 lpAmount) external returns (bool);
+  function onNFTWithdraw(address operator, uint256 tokenId, uint256 lpAmount) external returns (bool);
+}

--- a/src/contracts/for-test/NFTPool/interfaces/INFTPool.sol
+++ b/src/contracts/for-test/NFTPool/interfaces/INFTPool.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/token/ERC721/IERC721.sol';
+
+interface INFTPool is IERC721 {
+  function exists(uint256 tokenId) external view returns (bool);
+  function hasDeposits() external view returns (bool);
+  function getPoolInfo()
+    external
+    view
+    returns (
+      address lpToken,
+      address grailToken,
+      address sbtToken,
+      uint256 lastRewardTime,
+      uint256 accRewardsPerShare,
+      uint256 lpSupply,
+      uint256 lpSupplyWithMultiplier,
+      uint256 allocPoint
+    );
+  function getStakingPosition(uint256 tokenId)
+    external
+    view
+    returns (
+      uint256 amount,
+      uint256 amountWithMultiplier,
+      uint256 startLockTime,
+      uint256 lockDuration,
+      uint256 lockMultiplier,
+      uint256 rewardDebt,
+      uint256 boostPoints,
+      uint256 totalMultiplier
+    );
+
+  function boost(uint256 userAddress, uint256 amount) external;
+  function unboost(uint256 userAddress, uint256 amount) external;
+}

--- a/src/contracts/for-test/NFTPool/interfaces/IYieldBooster.sol
+++ b/src/contracts/for-test/NFTPool/interfaces/IYieldBooster.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IYieldBooster {
+  function deallocateAllFromPool(address userAddress, uint256 tokenId) external;
+  function getMultiplier(
+    address poolAddress,
+    uint256 maxBoostMultiplier,
+    uint256 amount,
+    uint256 totalPoolSupply,
+    uint256 allocatedAmount
+  ) external view returns (uint256);
+}

--- a/src/contracts/for-test/NFTPool/interfaces/tokens/IXGrailToken.sol
+++ b/src/contracts/for-test/NFTPool/interfaces/tokens/IXGrailToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/token/ERC20/IERC20.sol';
+
+interface IXGrailToken is IERC20 {
+  function usageAllocations(address userAddress, address usageAddress) external view returns (uint256 allocation);
+
+  function allocateFromUsage(address userAddress, uint256 amount) external;
+  function convertTo(uint256 amount, address to) external;
+  function deallocateFromUsage(address userAddress, uint256 amount) external;
+
+  function isTransferWhitelisted(address account) external view returns (bool);
+}

--- a/src/contracts/proxies/NFTPoolProxyHandler.sol
+++ b/src/contracts/proxies/NFTPoolProxyHandler.sol
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.19;
+
+import {NFTPool} from '@contracts/for-test/NFTPool/NFTPool.sol';
+import {INFTHandler} from '@contracts/for-test/NFTPool/interfaces/INFTHandler.sol';
+import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
+import {IERC721} from '@openzeppelin/token/ERC721/IERC721.sol';
+import {ODProxy} from '@contracts/proxies/ODProxy.sol';
+
+interface CamelotRouterV2 {
+  function removeLiquidity(
+    address tokenA,
+    address tokenB,
+    uint256 liquidity,
+    uint256 amountAMin,
+    uint256 amountBMin,
+    address to,
+    uint256 deadline
+  ) external returns (uint256 amountA, uint256 amountB);
+}
+
+interface INonfungiblePositionManager {
+  struct DecreaseLiquidityParams {
+    uint256 tokenId;
+    uint128 liquidity;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+  }
+
+  struct CollectParams {
+    uint256 tokenId;
+    address recipient;
+    uint128 amount0Max;
+    uint128 amount1Max;
+  }
+
+  function decreaseLiquidity(DecreaseLiquidityParams calldata params) external;
+
+  function collect(CollectParams calldata params) external returns (uint256 amount0, uint256 amount1);
+
+  function positions(uint256 tokenId)
+    external
+    view
+    returns (
+      uint96 nonce,
+      address operator,
+      address token0,
+      address token1,
+      int24 tickLower,
+      int24 tickUpper,
+      uint128 liquidity,
+      uint256 feeGrowthInside0LastX128,
+      uint256 feeGrowthInside1LastX128,
+      uint128 tokensOwed0,
+      uint128 tokensOwed1
+    );
+}
+
+// Generic interface for a liquidity pool.
+interface ILiquidityPool {
+  function token0() external view returns (address);
+  function token1() external view returns (address);
+
+  function withdraw(
+    uint256 shares,
+    uint256 amount0Min,
+    uint256 amount1Min,
+    address to
+  ) external returns (uint256 amount0, uint256 amount1);
+
+  // Uniswap V2
+  function removeLiquidity(
+    address tokenA,
+    address tokenB,
+    uint256 liquidity,
+    uint256 amountAMin,
+    uint256 amountBMin,
+    address to,
+    uint256 deadline
+  ) external returns (uint256 amountA, uint256 amountB);
+}
+
+/**
+ * @title  NFTPoolProxyHandler
+ * @notice This contract will unwinds the NFTPool position and transfer the tokens to the user ODProxy to be deposit on OD protocol
+ * @dev This contract is meant to be used by users that already have ODProxy contract
+ */
+contract NFTPoolProxyHandler is INFTHandler {
+  error NFT_HANDLER_POSITION_AMOUNT_ZERO();
+  error NTF_HANDLER_ROUTER_NOT_SET();
+
+  ODProxy public immutable odProxy;
+  address public immutable nftPool;
+  address public immutable proxyOwner; // don't call ODProxy.OWNER() multi times to save gas
+  address public immutable router; // depending on the version of the pool can be router v2 or v3
+
+  modifier onlyOwner() {
+    require(msg.sender == proxyOwner, 'NFTPoolProxyHandler: only ODProxy');
+    _;
+  }
+
+  // add more checks for each address
+  constructor(ODProxy _odProxy, address _nftPool, address _router) {
+    odProxy = _odProxy;
+    nftPool = _nftPool;
+    router = _router;
+    proxyOwner = _odProxy.OWNER();
+    assert(proxyOwner != address(0));
+  }
+
+  /**
+   * @notice Transfers the NFT to this contract
+   * @param from Address of the NFT to transfer
+   * @param tokenId ID of the NFT to transfer
+   * @return True on success
+   */
+  function transferFrom(address from, uint256 tokenId) public onlyOwner returns (bool) {
+    NFTPool(nftPool).safeTransferFrom(from, address(this), tokenId);
+    return true;
+  }
+  /**
+   * @notice Withdraws from a V2 position and sends underlying tokens to the ODProxy.
+   * @param tokenId ID of the NFT representing the position.
+   * @param amount0Min Minimum amount of token0 expected to prevent slippage.
+   * @param amount1Min Minimum amount of token1 expected to prevent slippage.
+   * @return True on success.
+   */
+
+  function withdrawFromPositionV2(
+    uint256 tokenId,
+    uint256 amount0Min,
+    uint256 amount1Min
+  ) public onlyOwner returns (bool) {
+    if (router == address(0)) {
+      revert NTF_HANDLER_ROUTER_NOT_SET();
+    }
+    uint256 positionAmount = _getPositionAmountV2(tokenId);
+    if (positionAmount == 0) {
+      revert NFT_HANDLER_POSITION_AMOUNT_ZERO();
+    }
+
+    ILiquidityPool liquidityPool = ILiquidityPool(_getLiquidityPool());
+    NFTPool(nftPool).withdrawFromPosition(tokenId, positionAmount);
+
+    uint256 shares = IERC20(address(liquidityPool)).balanceOf(address(this));
+
+    if (shares == 0) {
+      revert NFT_HANDLER_POSITION_AMOUNT_ZERO();
+    }
+    // approve router
+    IERC20(address(liquidityPool)).approve(router, shares);
+
+    CamelotRouterV2(router).removeLiquidity(
+      liquidityPool.token0(), liquidityPool.token1(), shares, amount0Min, amount1Min, address(odProxy), block.timestamp
+    );
+
+    return true;
+  }
+  /**
+   * @notice Withdraws from a V3 position and sends underlying tokens to the ODProxy.
+   * @param tokenId ID of the NFT representing the position.
+   * @param amount0Min Minimum amount of token0 expected to prevent slippage.
+   * @param amount1Min Minimum amount of token1 expected to prevent slippage.
+   * @return True on success.
+   */
+
+  function withdrawFromPositionV3(
+    uint256 tokenId,
+    uint256 amount0Min,
+    uint256 amount1Min
+  ) public onlyOwner returns (bool) {
+    uint128 liquidity = _getPositionLiquidityV3(tokenId);
+    if (liquidity == 0) {
+      revert NFT_HANDLER_POSITION_AMOUNT_ZERO();
+    }
+
+    NFTPool(nftPool).transferFrom(msg.sender, address(this), tokenId);
+    IERC721(nftPool).approve(router, tokenId);
+
+    INonfungiblePositionManager positionManager = INonfungiblePositionManager(nftPool);
+
+    // Decrease liquidity
+    positionManager.decreaseLiquidity(
+      INonfungiblePositionManager.DecreaseLiquidityParams({
+        tokenId: tokenId,
+        liquidity: liquidity,
+        amount0Min: amount0Min,
+        amount1Min: amount1Min,
+        deadline: block.timestamp
+      })
+    );
+
+    // Collect the tokens
+    positionManager.collect(
+      INonfungiblePositionManager.CollectParams({
+        tokenId: tokenId,
+        recipient: address(odProxy),
+        amount0Max: type(uint128).max,
+        amount1Max: type(uint128).max
+      })
+    );
+
+    return true;
+  }
+
+  /**
+   * @notice Transfers the tokens to the ODProxy.
+   * @param token Address of the token to transfer.
+   * @param to Address of the recipient.
+   * @param amount Amount of tokens to transfer.
+   * @return True on success.
+   */
+  function ERC20TransferTo(address token, address to, uint256 amount) public onlyOwner returns (bool) {
+    IERC20(token).transferFrom(address(this), to, amount);
+    return true;
+  }
+
+  /**
+   * @notice Transfers the NFT to the ODProxy.
+   * @param token Address of the NFT to transfer.
+   * @param to Address of the recipient.
+   * @param tokenId ID of the NFT to transfer.
+   * @return True on success.
+   */
+  function ERC721TransferTo(address token, address to, uint256 tokenId) public onlyOwner returns (bool) {
+    IERC721(token).transferFrom(address(this), to, tokenId);
+    return true;
+  }
+
+  // NFTPool interface
+  function onNFTAddToPosition(address operator, uint256 tokenId, uint256 lpAmount) external override returns (bool) {
+    return true;
+  }
+  // NFTPool interface
+
+  function onNFTHarvest(
+    address operator,
+    address to,
+    uint256 tokenId,
+    uint256 grailAmount,
+    uint256 xGrailAmount
+  ) external override returns (bool) {
+    return true;
+  }
+
+  // NFTPool interface
+  function onNFTWithdraw(address operator, uint256 tokenId, uint256 lpAmount) external override returns (bool) {
+    return true;
+  }
+
+  // ERC721Receiver interface
+  function onERC721Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data
+  ) external override returns (bytes4) {
+    return this.onERC721Received.selector;
+  }
+
+  /**
+   * @notice get the amount of the position
+   * @param tokenId ID of the NFT representing the position.
+   * @return amount of the position
+   */
+  function _getPositionAmountV2(uint256 tokenId) internal view returns (uint256 amount) {
+    (amount,,,,,,,) = NFTPool(nftPool).getStakingPosition(tokenId);
+  }
+
+  /**
+   * @notice get the liquidity of the position
+   * @param tokenId ID of the NFT representing the position.
+   * @return liquidity of the position
+   */
+  function _getPositionLiquidityV3(uint256 tokenId) internal view returns (uint128 liquidity) {
+    (,,,,,, liquidity,,,,) = INonfungiblePositionManager(nftPool).positions(tokenId);
+  }
+
+  function _getLiquidityPool() internal view returns (address lpToken) {
+    (lpToken,,,,,,,) = NFTPool(nftPool).getPoolInfo();
+  }
+}

--- a/test/testnet/unit/NFTPool/NFTPool.t.sol
+++ b/test/testnet/unit/NFTPool/NFTPool.t.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.19;
+
+import 'forge-std/Test.sol';
+import {NFTPool} from '@contracts/for-test/NFTPool/NFTPool.sol';
+import {INFTHandler} from '@contracts/for-test/NFTPool/interfaces/INFTHandler.sol';
+import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
+import {IERC721} from '@openzeppelin/token/ERC721/IERC721.sol';
+import {ERC20} from '@openzeppelin/token/ERC20/ERC20.sol';
+import {ICamelotMaster} from '@contracts/for-test/NFTPool/interfaces/ICamelotMaster.sol';
+import {IXGrailToken} from '@contracts/for-test/NFTPool/interfaces/tokens/IXGrailToken.sol';
+import {ODProxy} from '@contracts/proxies/ODProxy.sol';
+
+import {NFTPoolProxyHandler} from '@contracts/proxies/NFTPoolProxyHandler.sol';
+
+contract NFTPoolForkTestV2 is Test {
+  address ARBTIRUM_NFTPOOL_ADDR = 0x978E469E8242cd18af5926A1b60B8D93A550a391;
+  address ARBTIRUM_NITROPOOL_ADDR = 0x3a57539e4541AF96dB2Daf398A1F96eCaDC18883;
+  uint256 ARBTIRUM_BLOCK = 176_391_391;
+
+  address IMPERSONATOR_ADDR_V2 = 0x9cb3A7c1EEbe4444295fBE20960B220B8549351a; // random address that have NFT position
+  uint256 IMPERSONATOR_NFT_ID_V2 = 530;
+  address CAMELOT_ROUTER_V2 = 0xc873fEcbd354f5A56E00E710B90EF4201db2448d; // Camelot Router (Uniswap v2)
+  address POOL_ADDR_V2 = 0x913398d79438e8D709211cFC3DC8566F6C67e1A8; // NFTPool pair token
+  address TOKEN_0_V2 = 0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a; // GMX
+  address TOKEN_1_V2 = 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8; // Bridged USDC (USDC.e)
+
+  NFTPool nftPool;
+  ODProxy odProxy;
+  NFTPoolProxyHandler nftHandler;
+  IERC20 tokenPair;
+
+  function setUp() public {
+    // --- Arbitrum Fork ---
+
+    uint256 forkId = vm.createFork(vm.rpcUrl('mainnet'));
+    vm.selectFork(forkId);
+    vm.rollFork(ARBTIRUM_BLOCK);
+
+    // --- NFTPool ---
+    nftPool = NFTPool(ARBTIRUM_NFTPOOL_ADDR);
+
+    // --- Token Pair ---
+    tokenPair = IERC20(POOL_ADDR_V2);
+
+    // fund impersonator account
+    vm.deal(IMPERSONATOR_ADDR_V2, 100 ether);
+
+    // deploy ODProxy
+    odProxy = __deployODProxy();
+
+    // deploy NFTHandler
+    nftHandler = __deployNFTHandler(odProxy);
+  }
+
+  function testImpersonatorState() public {
+    // check impersonator NFT ownership
+    assertEq(nftPool.ownerOf(IMPERSONATOR_NFT_ID_V2), IMPERSONATOR_ADDR_V2);
+    // check impersonator eth balance
+    assertEq(100 ether, IMPERSONATOR_ADDR_V2.balance);
+  }
+
+  function testApproveAndTransferToNFTHandler() public {
+    // setup scenario: impersonator approves NFTHandler to transfer NFT, then transfers NFT to NFTHandler
+    vm.startPrank(IMPERSONATOR_ADDR_V2);
+    // check NFT ownership
+    assertEq(nftPool.ownerOf(IMPERSONATOR_NFT_ID_V2), IMPERSONATOR_ADDR_V2);
+    // approve NFTHandler to transfer NFT
+    nftPool.approve(address(nftHandler), IMPERSONATOR_NFT_ID_V2);
+    assertEq(nftPool.getApproved(IMPERSONATOR_NFT_ID_V2), address(nftHandler));
+    // transfer NFT to NFTHandler
+    nftHandler.transferFrom(IMPERSONATOR_ADDR_V2, IMPERSONATOR_NFT_ID_V2);
+    // check NFT ownership
+    assertEq(nftPool.ownerOf(IMPERSONATOR_NFT_ID_V2), address(nftHandler));
+  }
+
+  function testTransferToNFTHandlerWithoutApproval() public {
+    // setup scenario: impersonator transfers NFT to NFTHandler without approval
+    vm.startPrank(IMPERSONATOR_ADDR_V2);
+    // check NFT ownership
+    assertEq(nftPool.ownerOf(IMPERSONATOR_NFT_ID_V2), IMPERSONATOR_ADDR_V2);
+    // transfer NFT to NFTHandler
+    nftPool.safeTransferFrom(IMPERSONATOR_ADDR_V2, address(nftHandler), IMPERSONATOR_NFT_ID_V2);
+    // check NFT ownership
+    assertEq(nftPool.ownerOf(IMPERSONATOR_NFT_ID_V2), address(nftHandler));
+  }
+
+  function testWithdrawPositionV2() public {
+    // setup scenario: impersonator withdraws NFT from NFTHandler
+    vm.startPrank(IMPERSONATOR_ADDR_V2);
+
+    // ODProxy don't have any tokens
+    assertEq(tokenPair.balanceOf(address(odProxy)), 0);
+    assertEq(IERC20(TOKEN_0_V2).balanceOf(address(odProxy)), 0);
+    assertEq(IERC20(TOKEN_1_V2).balanceOf(address(odProxy)), 0);
+
+    // transfer NFT to NFTHandler
+    nftPool.safeTransferFrom(IMPERSONATOR_ADDR_V2, address(nftHandler), IMPERSONATOR_NFT_ID_V2);
+
+    // handler doesn't have any pairToken
+    assertEq(tokenPair.balanceOf(address(nftHandler)), 0);
+
+    // nftHandler withdraws position
+    nftHandler.withdrawFromPositionV2(IMPERSONATOR_NFT_ID_V2, 1, 1);
+
+    // at this phase the NFT should be burned
+    assertFalse(nftPool.exists(IMPERSONATOR_NFT_ID_V2));
+
+    // ODProxy should have tokens 0 and 1
+    assertEq(tokenPair.balanceOf(address(odProxy)), 0);
+    assertTrue(IERC20(TOKEN_0_V2).balanceOf(address(odProxy)) > 0);
+    assertTrue(IERC20(TOKEN_1_V2).balanceOf(address(odProxy)) > 0);
+  }
+
+  // Helper functions
+  function __deployODProxy() internal returns (ODProxy odProxy) {
+    vm.startPrank(IMPERSONATOR_ADDR_V2);
+    odProxy = new ODProxy(IMPERSONATOR_ADDR_V2);
+    assertEq(odProxy.OWNER(), IMPERSONATOR_ADDR_V2);
+  }
+
+  function __deployNFTHandler(ODProxy odProxy) internal returns (NFTPoolProxyHandler nftHandler) {
+    nftHandler = new NFTPoolProxyHandler(odProxy, address(nftPool), CAMELOT_ROUTER_V2);
+    assertEq(address(nftHandler.odProxy()), address(odProxy));
+    assertEq(address(nftHandler.nftPool()), address(nftPool));
+    assertEq(nftHandler.proxyOwner(), IMPERSONATOR_ADDR_V2);
+  }
+}
+
+contract NFTPoolForkTestV3 is Test {
+  // for V3 tests
+
+  uint256 ARBITRUM_BLOCK_V3 = 177_397_592;
+
+  address IMPERSONATOR_ADDR_V3 = 0xF482881968D1F1D99397310636fF9FaC070f63C6; // random address that have NFT position
+  uint256 IMPERSONATOR_NFT_ID_V3 = 1800; // random address that have NFT position
+  address CAMELOT_ROUTER_V3 = 0x1F721E2E82F6676FCE4eA07A5958cF098D339e18; // Camelot Router (Uniswap v3)
+  // address POOL_ADDR_V3 = 0x83F210dDa8D968094a8ea2a27E2A16D2b364c78A; // AlgebraPool
+  address POOL_ADDR_V3 = 0x00c7f3082833e796A5b3e4Bd59f6642FF44DCD15; // NonfungiblePositionManager
+  address TOKEN_0_V3 = 0x3d9907F9a368ad0a51Be60f7Da3b97cf940982D8; // Camelot Token
+  address TOKEN_1_V3 = 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8; // USDC
+
+  //NFT POSITION MANAGER 0x00c7f3082833e796a5b3e4bd59f6642ff44dcd15
+
+  NFTPool nftPool;
+  ODProxy odProxy;
+  NFTPoolProxyHandler nftHandler;
+  IERC20 tokenPair;
+
+  function setUp() public {
+    // --- Arbitrum Fork ---
+    uint256 forkId = vm.createFork(vm.rpcUrl('mainnet'));
+    vm.selectFork(forkId);
+    vm.rollFork(ARBITRUM_BLOCK_V3);
+
+    // --- NFTPool ---
+    nftPool = NFTPool(POOL_ADDR_V3);
+
+    // fund impersonator account
+    vm.deal(IMPERSONATOR_ADDR_V3, 100 ether);
+
+    // deploy ODProxy
+    odProxy = __deployODProxy();
+
+    // deploy NFTHandler
+    nftHandler = __deployNFTHandler(odProxy);
+  }
+
+  // Helper functions
+  function __deployODProxy() internal returns (ODProxy odProxy) {
+    vm.startPrank(IMPERSONATOR_ADDR_V3);
+    odProxy = new ODProxy(IMPERSONATOR_ADDR_V3);
+    assertEq(odProxy.OWNER(), IMPERSONATOR_ADDR_V3);
+  }
+
+  function __deployNFTHandler(ODProxy odProxy) internal returns (NFTPoolProxyHandler nftHandler) {
+    nftHandler = new NFTPoolProxyHandler(odProxy, address(nftPool), CAMELOT_ROUTER_V3);
+    assertEq(address(nftHandler.odProxy()), address(odProxy));
+    assertEq(address(nftHandler.nftPool()), address(nftPool));
+    assertEq(nftHandler.proxyOwner(), IMPERSONATOR_ADDR_V3);
+  }
+
+  function testWithdrawPositionV3() public {
+    // setup scenario: impersonator withdraws NFT from NFTHandler
+    vm.startPrank(IMPERSONATOR_ADDR_V3);
+
+    // ERC721 approve nftHandler
+    IERC721(POOL_ADDR_V3).approve(address(nftHandler), IMPERSONATOR_NFT_ID_V3);
+    // check if account is owner of token
+    assertEq(IERC721(POOL_ADDR_V3).ownerOf(IMPERSONATOR_NFT_ID_V3), IMPERSONATOR_ADDR_V3);
+    // nftHandler withdraws position
+    nftHandler.withdrawFromPositionV3(IMPERSONATOR_NFT_ID_V3, 0, 0);
+
+    assertTrue(IERC20(TOKEN_0_V3).balanceOf(address(odProxy)) == 0);
+    assertTrue(IERC20(TOKEN_1_V3).balanceOf(address(odProxy)) > 0);
+  }
+}


### PR DESCRIPTION
`NFTPoolProxyHandler` contract was designed to streamline interactions with NFT-based liquidity pools across different versions (V2 and V3) for users that have an `ODProxy`. 

It enables withdrawal of positions from NFT pools, handling the conversion to underlying tokens and ensuring those are sent to the user's ODProxy address.

I'm missing the last mile of depositing into OD. Will need @pi0neerpat or @daopunk help.