### PR TITLE
Fix: Redundant arguments when bidding on Auction Houses

### DIFF
--- a/src/contracts/DebtAuctionHouse.sol
+++ b/src/contracts/DebtAuctionHouse.sol
@@ -132,16 +132,16 @@ contract DebtAuctionHouse is Authorizable, Modifiable, Disableable, IDebtAuction
   }
 
   /// @inheritdoc IDebtAuctionHouse
-  function decreaseSoldAmount(uint256 _id, uint256 _amountToBuy, uint256 _bid) external whenEnabled {
+  function decreaseSoldAmount(uint256 _id, uint256 _amountToBuy) external whenEnabled {
     Auction storage _auction = _auctions[_id];
     if (_auction.highBidder == address(0)) revert DAH_HighBidderNotSet();
     if (_auction.bidExpiry <= block.timestamp && _auction.bidExpiry != 0) revert DAH_BidAlreadyExpired();
     if (_auction.auctionDeadline <= block.timestamp) revert DAH_AuctionAlreadyExpired();
 
-    if (_bid != _auction.bidAmount) revert DAH_NotMatchingBid();
     if (_amountToBuy >= _auction.amountToSell) revert DAH_AmountBoughtNotLower();
     if (_params.bidDecrease * _amountToBuy > _auction.amountToSell * WAD) revert DAH_InsufficientDecrease();
 
+    uint256 _bid = _auction.bidAmount;
     safeEngine.transferInternalCoins(msg.sender, _auction.highBidder, _bid);
 
     // on first bid submitted, clear as much totalOnAuctionDebt as possible

--- a/src/contracts/SurplusAuctionHouse.sol
+++ b/src/contracts/SurplusAuctionHouse.sol
@@ -131,12 +131,11 @@ contract SurplusAuctionHouse is Authorizable, Modifiable, Disableable, ISurplusA
   }
 
   /// @inheritdoc ICommonSurplusAuctionHouse
-  function increaseBidSize(uint256 _id, uint256 _amountToBuy, uint256 _bid) external whenEnabled {
+  function increaseBidSize(uint256 _id, uint256 _bid) external whenEnabled {
     Auction storage _auction = _auctions[_id];
     if (_auction.highBidder == address(0)) revert SAH_HighBidderNotSet();
     if (_auction.bidExpiry <= block.timestamp && _auction.bidExpiry != 0) revert SAH_BidAlreadyExpired();
     if (_auction.auctionDeadline <= block.timestamp) revert SAH_AuctionAlreadyExpired();
-    if (_amountToBuy != _auction.amountToSell) revert SAH_AmountsNotMatching();
     if (_bid <= _auction.bidAmount) revert SAH_BidNotHigher();
     if (_bid * WAD < _params.bidIncrease * _auction.bidAmount) revert SAH_InsufficientIncrease();
 
@@ -154,7 +153,7 @@ contract SurplusAuctionHouse is Authorizable, Modifiable, Disableable, ISurplusA
       _bidder: msg.sender,
       _blockTimestamp: block.timestamp,
       _raisedAmount: _bid,
-      _soldAmount: _amountToBuy,
+      _soldAmount: _auction.amountToSell,
       _bidExpiry: _auction.bidExpiry
     });
   }

--- a/src/contracts/proxies/actions/DebtBidActions.sol
+++ b/src/contracts/proxies/actions/DebtBidActions.sol
@@ -40,7 +40,7 @@ contract DebtBidActions is CommonActions, IDebtBidActions {
       _safeEngine.approveSAFEModification(address(_debtAuctionHouse));
     }
 
-    IDebtAuctionHouse(_debtAuctionHouse).decreaseSoldAmount(_auctionId, _soldAmount, _bidAmount);
+    IDebtAuctionHouse(_debtAuctionHouse).decreaseSoldAmount(_auctionId, _soldAmount);
   }
 
   /// @inheritdoc IDebtBidActions

--- a/src/contracts/proxies/actions/SurplusBidActions.sol
+++ b/src/contracts/proxies/actions/SurplusBidActions.sol
@@ -29,7 +29,7 @@ contract SurplusBidActions is ISurplusBidActions, CommonActions {
     _protocolToken.approve(address(_surplusAuctionHouse), _bidAmount);
 
     // proxy needs to be approved for protocol token spending
-    ISurplusAuctionHouse(_surplusAuctionHouse).increaseBidSize(_auctionId, _amountToSell, _bidAmount);
+    ISurplusAuctionHouse(_surplusAuctionHouse).increaseBidSize(_auctionId, _bidAmount);
   }
 
   /// @inheritdoc ISurplusBidActions

--- a/src/contracts/settlement/PostSettlementSurplusAuctionHouse.sol
+++ b/src/contracts/settlement/PostSettlementSurplusAuctionHouse.sol
@@ -115,12 +115,11 @@ contract PostSettlementSurplusAuctionHouse is Authorizable, Modifiable, IPostSet
   }
 
   /// @inheritdoc ICommonSurplusAuctionHouse
-  function increaseBidSize(uint256 _id, uint256 _amountToBuy, uint256 _bid) external {
+  function increaseBidSize(uint256 _id, uint256 _bid) external {
     Auction storage _auction = _auctions[_id];
     if (_auction.highBidder == address(0)) revert SAH_HighBidderNotSet();
     if (_auction.bidExpiry <= block.timestamp && _auction.bidExpiry != 0) revert SAH_BidAlreadyExpired();
     if (_auction.auctionDeadline <= block.timestamp) revert SAH_AuctionAlreadyExpired();
-    if (_amountToBuy != _auction.amountToSell) revert SAH_AmountsNotMatching();
     if (_bid <= _auction.bidAmount) revert SAH_BidNotHigher();
     if (_bid * WAD < _params.bidIncrease * _auction.bidAmount) revert SAH_InsufficientIncrease();
 
@@ -133,7 +132,7 @@ contract PostSettlementSurplusAuctionHouse is Authorizable, Modifiable, IPostSet
     _auction.bidAmount = _bid;
     _auction.bidExpiry = block.timestamp + _params.bidDuration;
 
-    emit IncreaseBidSize(_id, msg.sender, block.timestamp, _bid, _amountToBuy, _auction.bidExpiry);
+    emit IncreaseBidSize(_id, msg.sender, block.timestamp, _bid, _auction.amountToSell, _auction.bidExpiry);
   }
 
   /// @inheritdoc ICommonSurplusAuctionHouse

--- a/src/interfaces/ICommonSurplusAuctionHouse.sol
+++ b/src/interfaces/ICommonSurplusAuctionHouse.sol
@@ -161,10 +161,9 @@ interface ICommonSurplusAuctionHouse {
   /**
    * @notice Submit a higher protocol token bid for the same amount of system coins
    * @param  _id ID of the auction you want to submit the bid for
-   * @param  _amountToBuy Amount of system coins to buy [rad]
    * @param  _bid New bid submitted [wad]
    */
-  function increaseBidSize(uint256 _id, uint256 _amountToBuy, uint256 _bid) external;
+  function increaseBidSize(uint256 _id, uint256 _bid) external;
 
   /**
    * @notice Settle/finish an auction

--- a/src/interfaces/IDebtAuctionHouse.sol
+++ b/src/interfaces/IDebtAuctionHouse.sol
@@ -222,9 +222,8 @@ interface IDebtAuctionHouse is IAuthorizable, IModifiable, IDisableable {
    *         exchange for providing the same amount of system coins being raised by the auction
    * @param  _id ID of the auction for which you want to submit a new bid
    * @param  _amountToBuy Amount of protocol tokens to buy (must be smaller than the previous proposed amount) [wad]
-   * @param  _bid New system coin bid (must always equal the total amount raised by the auction) [rad]
    */
-  function decreaseSoldAmount(uint256 _id, uint256 _amountToBuy, uint256 _bid) external;
+  function decreaseSoldAmount(uint256 _id, uint256 _amountToBuy) external;
 
   /**
    * @notice Settle an auction

--- a/test/testnet/scopes/DirectUser.t.sol
+++ b/test/testnet/scopes/DirectUser.t.sol
@@ -177,7 +177,7 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
     systemCoin.approve(address(coinJoin), _amountToBid / 1e27);
     coinJoin.join(_user, _amountToBid / 1e27);
     safeEngine.approveSAFEModification(address(debtAuctionHouse));
-    debtAuctionHouse.decreaseSoldAmount(_auctionId, _amountToBuy, _amountToBid);
+    debtAuctionHouse.decreaseSoldAmount(_auctionId, _amountToBuy);
     vm.stopPrank();
   }
 
@@ -186,11 +186,9 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
   }
 
   function _increaseBidSize(address _user, uint256 _auctionId, uint256 _bidAmount) internal override {
-    uint256 _amountToSell = surplusAuctionHouse.auctions(_auctionId).amountToSell;
-
     vm.startPrank(_user);
     protocolToken.approve(address(surplusAuctionHouse), _bidAmount);
-    surplusAuctionHouse.increaseBidSize(_auctionId, _amountToSell, _bidAmount);
+    surplusAuctionHouse.increaseBidSize(_auctionId, _bidAmount);
     vm.stopPrank();
   }
 
@@ -209,11 +207,9 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
   // --- Global Settlement actions ---
 
   function _increasePostSettlementBidSize(address _user, uint256 _auctionId, uint256 _bidAmount) internal override {
-    uint256 _amountToSell = postSettlementSurplusAuctionHouse.auctions(_auctionId).amountToSell;
-
     vm.startPrank(_user);
     protocolToken.approve(address(postSettlementSurplusAuctionHouse), _bidAmount);
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auctionId, _amountToSell, _bidAmount);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auctionId, _bidAmount);
     vm.stopPrank();
   }
 

--- a/test/testnet/single/AccountingEngine.t.sol
+++ b/test/testnet/single/AccountingEngine.t.sol
@@ -84,9 +84,9 @@ contract SingleAccountingEngineTest is DSTest {
     (ok,) = address(accountingEngine).call(abi.encodeWithSignature(sig, era));
   }
 
-  function _try_decreaseSoldAmount(uint256 id, uint256 amountToBuy, uint256 bid) internal returns (bool ok) {
-    string memory sig = 'decreaseSoldAmount(uint256,uint256,uint256)';
-    (ok,) = address(debtAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy, bid));
+  function _try_decreaseSoldAmount(uint256 id, uint256 amountToBuy) internal returns (bool ok) {
+    string memory sig = 'decreaseSoldAmount(uint256,uint256)';
+    (ok,) = address(debtAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy));
   }
 
   function try_call(address addr, bytes calldata data) external returns (bool ok) {
@@ -382,7 +382,7 @@ contract SingleAccountingEngineTest is DSTest {
     uint256 id = accountingEngine.auctionDebt();
 
     safeEngine.createUnbackedDebt(address(0), address(this), rad(100 ether));
-    debtAuctionHouse.decreaseSoldAmount(id, 0 ether, rad(100 ether));
+    debtAuctionHouse.decreaseSoldAmount(id, 0 ether);
 
     assertTrue(!can_auctionSurplus());
   }
@@ -395,7 +395,7 @@ contract SingleAccountingEngineTest is DSTest {
     uint256 id = accountingEngine.auctionDebt();
 
     safeEngine.createUnbackedDebt(address(0), address(this), rad(100 ether));
-    debtAuctionHouse.decreaseSoldAmount(id, 0 ether, rad(100 ether));
+    debtAuctionHouse.decreaseSoldAmount(id, 0 ether);
 
     assertTrue(!can_auctionSurplus());
   }
@@ -405,7 +405,7 @@ contract SingleAccountingEngineTest is DSTest {
     uint256 id = accountingEngine.auctionDebt();
     safeEngine.createUnbackedDebt(address(0), address(this), rad(100 ether));
 
-    debtAuctionHouse.decreaseSoldAmount(id, 0 ether, rad(100 ether)); // debt auction succeeds..
+    debtAuctionHouse.decreaseSoldAmount(id, 0 ether); // debt auction succeeds..
 
     assertTrue(!can_auctionSurplus());
   }
@@ -418,7 +418,7 @@ contract SingleAccountingEngineTest is DSTest {
     uint256 id = accountingEngine.auctionDebt();
     safeEngine.createUnbackedDebt(address(0), address(this), rad(100 ether));
 
-    debtAuctionHouse.decreaseSoldAmount(id, 0 ether, rad(100 ether)); // debt auction succeeds..
+    debtAuctionHouse.decreaseSoldAmount(id, 0 ether); // debt auction succeeds..
 
     assertTrue(!can_auctionSurplus());
   }
@@ -428,9 +428,9 @@ contract SingleAccountingEngineTest is DSTest {
     uint256 id = accountingEngine.auctionDebt();
 
     safeEngine.createUnbackedDebt(address(0), address(this), rad(100 ether));
-    assertTrue(_try_decreaseSoldAmount(id, 2 ether, rad(100 ether)));
+    assertTrue(_try_decreaseSoldAmount(id, 2 ether));
 
     safeEngine.createUnbackedDebt(address(0), address(this), rad(100 ether));
-    assertTrue(_try_decreaseSoldAmount(id, 1 ether, rad(100 ether)));
+    assertTrue(_try_decreaseSoldAmount(id, 1 ether));
   }
 }

--- a/test/testnet/single/DebtAuctionHouse.t.sol
+++ b/test/testnet/single/DebtAuctionHouse.t.sol
@@ -21,17 +21,17 @@ contract Guy {
     debtAuctionHouse.protocolToken().approve(address(debtAuctionHouse), type(uint256).max);
   }
 
-  function decreaseSoldAmount(uint256 id, uint256 amountToBuy, uint256 bid) public {
-    debtAuctionHouse.decreaseSoldAmount(id, amountToBuy, bid);
+  function decreaseSoldAmount(uint256 id, uint256 amountToBuy) public {
+    debtAuctionHouse.decreaseSoldAmount(id, amountToBuy);
   }
 
   function settleAuction(uint256 id) public {
     debtAuctionHouse.settleAuction(id);
   }
 
-  function try_decreaseSoldAmount(uint256 id, uint256 amountToBuy, uint256 bid) public returns (bool ok) {
-    string memory sig = 'decreaseSoldAmount(uint256,uint256,uint256)';
-    (ok,) = address(debtAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy, bid));
+  function try_decreaseSoldAmount(uint256 id, uint256 amountToBuy) public returns (bool ok) {
+    string memory sig = 'decreaseSoldAmount(uint256,uint256)';
+    (ok,) = address(debtAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy));
   }
 
   function try_settleAuction(uint256 id) public returns (bool ok) {
@@ -137,14 +137,14 @@ contract SingleDebtAuctionHouseTest is DSTest {
   function test_decreaseSoldAmount() public {
     uint256 id = accountingEngine.startAuction(debtAuctionHouse, /*amountToSell*/ 200 ether, /*bid*/ 10 ether);
 
-    Guy(ali).decreaseSoldAmount(id, 100 ether, 10 ether);
+    Guy(ali).decreaseSoldAmount(id, 100 ether);
     // bid taken from bidder
     assertEq(safeEngine.coinBalance(ali), 190 ether);
     // accountingEngine receives payment
     assertEq(safeEngine.coinBalance(address(accountingEngine)), 10 ether);
     assertEq(accountingEngine.totalOnAuctionDebt(), 0 ether);
 
-    Guy(bob).decreaseSoldAmount(id, 80 ether, 10 ether);
+    Guy(bob).decreaseSoldAmount(id, 80 ether);
     // bid taken from bidder
     assertEq(safeEngine.coinBalance(bob), 190 ether);
     // prev bidder refunded
@@ -170,14 +170,14 @@ contract SingleDebtAuctionHouseTest is DSTest {
     accountingEngine.cancelAuctionedDebtWithSurplus(1 ether);
     assertEq(accountingEngine.totalOnAuctionDebt(), 9 ether);
 
-    Guy(ali).decreaseSoldAmount(id, 100 ether, 10 ether);
+    Guy(ali).decreaseSoldAmount(id, 100 ether);
     // bid taken from bidder
     assertEq(safeEngine.coinBalance(ali), 190 ether);
     // accountingEngine receives payment
     assertEq(safeEngine.coinBalance(address(accountingEngine)), 10 ether);
     assertEq(accountingEngine.totalOnAuctionDebt(), 0 ether);
 
-    Guy(bob).decreaseSoldAmount(id, 80 ether, 10 ether);
+    Guy(bob).decreaseSoldAmount(id, 80 ether);
     // bid taken from bidder
     assertEq(safeEngine.coinBalance(bob), 190 ether);
     // prev bidder refunded
@@ -204,7 +204,7 @@ contract SingleDebtAuctionHouseTest is DSTest {
     // run past the end
     hevm.warp(block.timestamp + 2 weeks);
     // check not biddable
-    assertTrue(!Guy(ali).try_decreaseSoldAmount(id, 100 ether, 10 ether));
+    assertTrue(!Guy(ali).try_decreaseSoldAmount(id, 100 ether));
     assertTrue(Guy(ali).try_restart_auction(id));
     // left auction in the accounting engine
     assertEq(debtAuctionHouse.activeDebtAuctions(), id);
@@ -212,7 +212,7 @@ contract SingleDebtAuctionHouseTest is DSTest {
     uint256 _amountToSell = debtAuctionHouse.auctions(id).amountToSell;
     // restart should increase the amountToSell by pad (50%) and restart the auction
     assertEq(_amountToSell, 300 ether);
-    assertTrue(Guy(ali).try_decreaseSoldAmount(id, 100 ether, 10 ether));
+    assertTrue(Guy(ali).try_decreaseSoldAmount(id, 100 ether));
   }
 
   function test_no_deal_after_settlement() public {
@@ -240,8 +240,8 @@ contract SingleDebtAuctionHouseTest is DSTest {
     assertEq(safeEngine.coinBalance(address(accountingEngine)), 0);
     assertEq(safeEngine.debtBalance(address(accountingEngine)), 0);
 
-    Guy(ali).decreaseSoldAmount(id, 100 ether, 10 ether);
-    Guy(bob).decreaseSoldAmount(id, 80 ether, 10 ether);
+    Guy(ali).decreaseSoldAmount(id, 100 ether);
+    Guy(bob).decreaseSoldAmount(id, 80 ether);
 
     // confirm the proper state updates have occurred
     assertEq(safeEngine.coinBalance(ali), 200 ether); // ali's coin balance is unchanged

--- a/test/testnet/single/SAFEEngine.t.sol
+++ b/test/testnet/single/SAFEEngine.t.sol
@@ -1089,7 +1089,7 @@ contract SingleLiquidationTest is DSTest {
     assertEq(accountingEngine.unqueuedUnauctionedDebt(), rad(90 ether));
     assertEq(safeEngine.coinBalance(address(accountingEngine)), rad(0 ether));
     assertEq(accountingEngine.totalOnAuctionDebt(), rad(10 ether));
-    debtAuctionHouse.decreaseSoldAmount(f1, 1000 ether, rad(10 ether));
+    debtAuctionHouse.decreaseSoldAmount(f1, 1000 ether);
     assertEq(accountingEngine.unqueuedUnauctionedDebt(), rad(90 ether));
     assertEq(safeEngine.coinBalance(address(accountingEngine)), rad(0 ether));
     assertEq(accountingEngine.totalOnAuctionDebt(), rad(0 ether));
@@ -1116,9 +1116,9 @@ contract SingleLiquidationTest is DSTest {
     assertEq(accountingEngine.totalOnAuctionDebt(), 0 ether);
     uint256 id = accountingEngine.auctionSurplus();
 
-    assertEq(safeEngine.coinBalance(mockExtraSurplusReceiver), 0 ether);
-    assertEq(protocolToken.balanceOf(mockExtraSurplusReceiver), 100 ether);
-    surplusAuctionHouse.increaseBidSize(id, rad(100 ether), 10 ether);
+    assertEq(safeEngine.coinBalance(address(this)), 0 ether);
+    assertEq(protocolToken.balanceOf(address(this)), 100 ether);
+    surplusAuctionHouse.increaseBidSize(id, 10 ether);
     hevm.warp(block.timestamp + 4 hours);
 
     surplusAuctionHouse.settleAuction(id);

--- a/test/testnet/single/SurplusAuctionHouse.t.sol
+++ b/test/testnet/single/SurplusAuctionHouse.t.sol
@@ -27,17 +27,17 @@ contract GuyBurningSurplusAuction {
     surplusAuctionHouse.protocolToken().approve(address(surplusAuctionHouse), type(uint256).max);
   }
 
-  function increaseBidSize(uint256 id, uint256 amountToBuy, uint256 bid) public {
-    surplusAuctionHouse.increaseBidSize(id, amountToBuy, bid);
+  function increaseBidSize(uint256 id, uint256 bid) public {
+    surplusAuctionHouse.increaseBidSize(id, bid);
   }
 
   function settleAuction(uint256 id) public {
     surplusAuctionHouse.settleAuction(id);
   }
 
-  function try_increaseBidSize(uint256 id, uint256 amountToBuy, uint256 bid) public returns (bool ok) {
-    string memory sig = 'increaseBidSize(uint256,uint256,uint256)';
-    (ok,) = address(surplusAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy, bid));
+  function try_increaseBidSize(uint256 id, uint256 bid) public returns (bool ok) {
+    string memory sig = 'increaseBidSize(uint256,uint256)';
+    (ok,) = address(surplusAuctionHouse).call(abi.encodeWithSignature(sig, id, bid));
   }
 
   function try_settleAuction(uint256 id) public returns (bool ok) {
@@ -60,17 +60,17 @@ contract GuyRecyclingSurplusAuction {
     surplusAuctionHouse.protocolToken().approve(address(surplusAuctionHouse), type(uint256).max);
   }
 
-  function increaseBidSize(uint256 id, uint256 amountToBuy, uint256 bid) public {
-    surplusAuctionHouse.increaseBidSize(id, amountToBuy, bid);
+  function increaseBidSize(uint256 id, uint256 bid) public {
+    surplusAuctionHouse.increaseBidSize(id, bid);
   }
 
   function settleAuction(uint256 id) public {
     surplusAuctionHouse.settleAuction(id);
   }
 
-  function try_increaseBidSize(uint256 id, uint256 amountToBuy, uint256 bid) public returns (bool ok) {
-    string memory sig = 'increaseBidSize(uint256,uint256,uint256)';
-    (ok,) = address(surplusAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy, bid));
+  function try_increaseBidSize(uint256 id, uint256 bid) public returns (bool ok) {
+    string memory sig = 'increaseBidSize(uint256,uint256)';
+    (ok,) = address(surplusAuctionHouse).call(abi.encodeWithSignature(sig, id, bid));
   }
 
   function try_settleAuction(uint256 id) public returns (bool ok) {
@@ -93,17 +93,17 @@ contract GuyPostSurplusAuction {
     surplusAuctionHouse.protocolToken().approve(address(surplusAuctionHouse), type(uint256).max);
   }
 
-  function increaseBidSize(uint256 id, uint256 amountToBuy, uint256 bid) public {
-    surplusAuctionHouse.increaseBidSize(id, amountToBuy, bid);
+  function increaseBidSize(uint256 id, uint256 bid) public {
+    surplusAuctionHouse.increaseBidSize(id, bid);
   }
 
   function settleAuction(uint256 id) public {
     surplusAuctionHouse.settleAuction(id);
   }
 
-  function try_increaseBidSize(uint256 id, uint256 amountToBuy, uint256 bid) public returns (bool ok) {
-    string memory sig = 'increaseBidSize(uint256,uint256,uint256)';
-    (ok,) = address(surplusAuctionHouse).call(abi.encodeWithSignature(sig, id, amountToBuy, bid));
+  function try_increaseBidSize(uint256 id, uint256 bid) public returns (bool ok) {
+    string memory sig = 'increaseBidSize(uint256,uint256)';
+    (ok,) = address(surplusAuctionHouse).call(abi.encodeWithSignature(sig, id, bid));
   }
 
   function try_settleAuction(uint256 id) public returns (bool ok) {
@@ -168,9 +168,9 @@ contract SingleBurningSurplusAuctionHouseTest is DSTest {
 
   function test_increase_bid_same_bidder() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    GuyBurningSurplusAuction(ali).increaseBidSize(id, 100 ether, 190 ether);
+    GuyBurningSurplusAuction(ali).increaseBidSize(id, 190 ether);
     assertEq(protocolToken.balanceOf(ali), 10 ether);
-    GuyBurningSurplusAuction(ali).increaseBidSize(id, 100 ether, 200 ether);
+    GuyBurningSurplusAuction(ali).increaseBidSize(id, 200 ether);
     assertEq(protocolToken.balanceOf(ali), 0);
   }
 
@@ -179,13 +179,13 @@ contract SingleBurningSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyBurningSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyBurningSurplusAuction(ali).increaseBidSize(id, 1 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(ali), 199 ether);
     // payment remains in auction
     assertEq(protocolToken.balanceOf(address(surplusAuctionHouse)), 1 ether);
 
-    GuyBurningSurplusAuction(bob).increaseBidSize(id, 100 ether, 2 ether);
+    GuyBurningSurplusAuction(bob).increaseBidSize(id, 2 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(bob), 198 ether);
     // prev bidder refunded
@@ -204,11 +204,11 @@ contract SingleBurningSurplusAuctionHouseTest is DSTest {
 
   function test_bid_increase() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    assertTrue(GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.0 ether));
-    assertTrue(!GuyBurningSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.01 ether));
+    assertTrue(GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 1.0 ether));
+    assertTrue(!GuyBurningSurplusAuction(bob).try_increaseBidSize(id, 1.01 ether));
     // high bidder is subject to beg
-    assertTrue(!GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.01 ether));
-    assertTrue(GuyBurningSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.07 ether));
+    assertTrue(!GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 1.01 ether));
+    assertTrue(GuyBurningSurplusAuction(bob).try_increaseBidSize(id, 1.07 ether));
   }
 
   function test_restart_auction() public {
@@ -219,10 +219,10 @@ contract SingleBurningSurplusAuctionHouseTest is DSTest {
     // run past the end
     hevm.warp(block.timestamp + 2 weeks);
     // check not biddable
-    assertTrue(!GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(!GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
     assertTrue(GuyBurningSurplusAuction(ali).try_restartAuction(id));
     // check biddable
-    assertTrue(GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(GuyBurningSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
   }
 
   function testFail_terminate_prematurely() public {
@@ -230,7 +230,7 @@ contract SingleBurningSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyBurningSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyBurningSurplusAuction(ali).increaseBidSize(id, 1 ether);
     surplusAuctionHouse.terminateAuctionPrematurely(id);
   }
 
@@ -239,7 +239,7 @@ contract SingleBurningSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyBurningSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyBurningSurplusAuction(ali).increaseBidSize(id, 1 ether);
     // Shutdown
     surplusAuctionHouse.disableContract();
     surplusAuctionHouse.terminateAuctionPrematurely(id);
@@ -303,9 +303,9 @@ contract SingleRecyclingSurplusAuctionHouseTest is DSTest {
 
   function test_increase_bid_same_bidder() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 190 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 190 ether);
     assertEq(protocolToken.balanceOf(ali), 10 ether);
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 200 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 200 ether);
     assertEq(protocolToken.balanceOf(ali), 0);
   }
 
@@ -314,13 +314,13 @@ contract SingleRecyclingSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 1 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(ali), 199 ether);
     // payment remains in auction
     assertEq(protocolToken.balanceOf(address(surplusAuctionHouse)), 1 ether);
 
-    GuyRecyclingSurplusAuction(bob).increaseBidSize(id, 100 ether, 2 ether);
+    GuyRecyclingSurplusAuction(bob).increaseBidSize(id, 2 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(bob), 198 ether);
     // prev bidder refunded
@@ -340,11 +340,11 @@ contract SingleRecyclingSurplusAuctionHouseTest is DSTest {
 
   function test_bid_increase() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.0 ether));
-    assertTrue(!GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.01 ether));
+    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1.0 ether));
+    assertTrue(!GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 1.01 ether));
     // high bidder is subject to beg
-    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.01 ether));
-    assertTrue(GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.07 ether));
+    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1.01 ether));
+    assertTrue(GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 1.07 ether));
   }
 
   function test_restart_auction() public {
@@ -355,10 +355,10 @@ contract SingleRecyclingSurplusAuctionHouseTest is DSTest {
     // run past the end
     hevm.warp(block.timestamp + 2 weeks);
     // check not biddable
-    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
     assertTrue(GuyRecyclingSurplusAuction(ali).try_restartAuction(id));
     // check biddable
-    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
   }
 
   function testFail_terminate_prematurely() public {
@@ -366,7 +366,7 @@ contract SingleRecyclingSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 1 ether);
     surplusAuctionHouse.terminateAuctionPrematurely(id);
   }
 
@@ -375,7 +375,7 @@ contract SingleRecyclingSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 1 ether);
     // Shutdown
     surplusAuctionHouse.disableContract();
     surplusAuctionHouse.terminateAuctionPrematurely(id);
@@ -439,9 +439,9 @@ contract SingleMixedStratSurplusAuctionHouseTest is DSTest {
 
   function test_increase_bid_same_bidder() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 190 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 190 ether);
     assertEq(protocolToken.balanceOf(ali), 10 ether);
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 200 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 200 ether);
     assertEq(protocolToken.balanceOf(ali), 0);
   }
 
@@ -450,13 +450,13 @@ contract SingleMixedStratSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 1 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(ali), 199 ether);
     // payment remains in auction
     assertEq(protocolToken.balanceOf(address(surplusAuctionHouse)), 1 ether);
 
-    GuyRecyclingSurplusAuction(bob).increaseBidSize(id, 100 ether, 2 ether);
+    GuyRecyclingSurplusAuction(bob).increaseBidSize(id, 2 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(bob), 198 ether);
     // prev bidder refunded
@@ -479,11 +479,11 @@ contract SingleMixedStratSurplusAuctionHouseTest is DSTest {
 
   function test_bid_increase() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.0 ether));
-    assertTrue(!GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.01 ether));
+    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1.0 ether));
+    assertTrue(!GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 1.01 ether));
     // high bidder is subject to beg
-    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.01 ether));
-    assertTrue(GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.07 ether));
+    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1.01 ether));
+    assertTrue(GuyRecyclingSurplusAuction(bob).try_increaseBidSize(id, 1.07 ether));
   }
 
   function test_restart_auction() public {
@@ -494,10 +494,10 @@ contract SingleMixedStratSurplusAuctionHouseTest is DSTest {
     // run past the end
     hevm.warp(block.timestamp + 2 weeks);
     // check not biddable
-    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(!GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
     assertTrue(GuyRecyclingSurplusAuction(ali).try_restartAuction(id));
     // check biddable
-    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(GuyRecyclingSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
   }
 
   function testFail_terminate_prematurely() public {
@@ -505,7 +505,7 @@ contract SingleMixedStratSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 1 ether);
     surplusAuctionHouse.terminateAuctionPrematurely(id);
   }
 
@@ -514,7 +514,7 @@ contract SingleMixedStratSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyRecyclingSurplusAuction(ali).increaseBidSize(id, 1 ether);
     // Shutdown
     surplusAuctionHouse.disableContract();
     surplusAuctionHouse.terminateAuctionPrematurely(id);
@@ -569,9 +569,9 @@ contract SinglePostSettlementSurplusAuctionHouseTest is DSTest {
 
   function test_increase_bid_same_bidder() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    GuyPostSurplusAuction(ali).increaseBidSize(id, 100 ether, 190 ether);
+    GuyPostSurplusAuction(ali).increaseBidSize(id, 190 ether);
     assertEq(protocolToken.balanceOf(ali), 10 ether);
-    GuyPostSurplusAuction(ali).increaseBidSize(id, 100 ether, 200 ether);
+    GuyPostSurplusAuction(ali).increaseBidSize(id, 200 ether);
     assertEq(protocolToken.balanceOf(ali), 0);
   }
 
@@ -580,13 +580,13 @@ contract SinglePostSettlementSurplusAuctionHouseTest is DSTest {
     // amount to buy taken from creator
     assertEq(safeEngine.coinBalance(address(this)), 900 ether);
 
-    GuyPostSurplusAuction(ali).increaseBidSize(id, 100 ether, 1 ether);
+    GuyPostSurplusAuction(ali).increaseBidSize(id, 1 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(ali), 199 ether);
     // payment remains in auction
     assertEq(protocolToken.balanceOf(address(surplusAuctionHouse)), 1 ether);
 
-    GuyPostSurplusAuction(bob).increaseBidSize(id, 100 ether, 2 ether);
+    GuyPostSurplusAuction(bob).increaseBidSize(id, 2 ether);
     // bid taken from bidder
     assertEq(protocolToken.balanceOf(bob), 198 ether);
     // prev bidder refunded
@@ -605,11 +605,11 @@ contract SinglePostSettlementSurplusAuctionHouseTest is DSTest {
 
   function test_bid_increase() public {
     uint256 id = surplusAuctionHouse.startAuction({_amountToSell: 100 ether, _initialBid: 0});
-    assertTrue(GuyPostSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.0 ether));
-    assertTrue(!GuyPostSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.01 ether));
+    assertTrue(GuyPostSurplusAuction(ali).try_increaseBidSize(id, 1.0 ether));
+    assertTrue(!GuyPostSurplusAuction(bob).try_increaseBidSize(id, 1.01 ether));
     // high bidder is subject to beg
-    assertTrue(!GuyPostSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1.01 ether));
-    assertTrue(GuyPostSurplusAuction(bob).try_increaseBidSize(id, 100 ether, 1.07 ether));
+    assertTrue(!GuyPostSurplusAuction(ali).try_increaseBidSize(id, 1.01 ether));
+    assertTrue(GuyPostSurplusAuction(bob).try_increaseBidSize(id, 1.07 ether));
   }
 
   function test_restart_auction() public {
@@ -620,9 +620,9 @@ contract SinglePostSettlementSurplusAuctionHouseTest is DSTest {
     // run past the end
     hevm.warp(block.timestamp + 2 weeks);
     // check not biddable
-    assertTrue(!GuyPostSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(!GuyPostSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
     assertTrue(GuyPostSurplusAuction(ali).try_restartAuction(id));
     // check biddable
-    assertTrue(GuyPostSurplusAuction(ali).try_increaseBidSize(id, 100 ether, 1 ether));
+    assertTrue(GuyPostSurplusAuction(ali).try_increaseBidSize(id, 1 ether));
   }
 }

--- a/test/testnet/unit/DebtAuctionHouse.t.sol
+++ b/test/testnet/unit/DebtAuctionHouse.t.sol
@@ -533,25 +533,25 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
     _mockTotalOnAuctionDebt(_totalOnAuctionDebt);
   }
 
-  function test_Revert_ContractIsDisabled(DebtAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_ContractIsDisabled(DebtAuction memory _auction, uint256 _amountToBuy) public {
     _mockContractEnabled(false);
 
     vm.expectRevert(IDisableable.ContractIsDisabled.selector);
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _bid);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
-  function test_Revert_HighBidderNotSet(DebtAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_HighBidderNotSet(DebtAuction memory _auction, uint256 _amountToBuy) public {
     _auction.highBidder = address(0);
 
     _mockValues(_auction, 0, 0, 0);
 
     vm.expectRevert(IDebtAuctionHouse.DAH_HighBidderNotSet.selector);
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _bid);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
-  function test_Revert_BidAlreadyExpired(DebtAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_BidAlreadyExpired(DebtAuction memory _auction, uint256 _amountToBuy) public {
     vm.assume(_auction.highBidder != address(0));
     vm.assume(_auction.bidExpiry != 0 && _auction.bidExpiry <= block.timestamp);
 
@@ -559,10 +559,10 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
 
     vm.expectRevert(IDebtAuctionHouse.DAH_BidAlreadyExpired.selector);
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _bid);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
-  function test_Revert_AuctionAlreadyExpired(DebtAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_AuctionAlreadyExpired(DebtAuction memory _auction, uint256 _amountToBuy) public {
     vm.assume(_auction.highBidder != address(0));
     vm.assume(_auction.bidExpiry == 0 || _auction.bidExpiry > block.timestamp);
     vm.assume(_auction.auctionDeadline <= block.timestamp);
@@ -571,20 +571,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
 
     vm.expectRevert(IDebtAuctionHouse.DAH_AuctionAlreadyExpired.selector);
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _bid);
-  }
-
-  function test_Revert_NotMatchingBid(DebtAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
-    vm.assume(_auction.highBidder != address(0));
-    vm.assume(_auction.bidExpiry == 0 || _auction.bidExpiry > block.timestamp);
-    vm.assume(_auction.auctionDeadline > block.timestamp);
-    vm.assume(_bid != _auction.bidAmount);
-
-    _mockValues(_auction, 0, 0, 0);
-
-    vm.expectRevert(IDebtAuctionHouse.DAH_NotMatchingBid.selector);
-
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _bid);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
   function test_Revert_AmountBoughtNotLower(DebtAuction memory _auction, uint256 _amountToBuy) public {
@@ -597,7 +584,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
 
     vm.expectRevert(IDebtAuctionHouse.DAH_AmountBoughtNotLower.selector);
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
   function test_Revert_InsufficientDecrease(
@@ -617,7 +604,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
 
     vm.expectRevert(IDebtAuctionHouse.DAH_InsufficientDecrease.selector);
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
   function test_Call_SafeEngine_TransferInternalCoins(
@@ -632,7 +619,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
       1
     );
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
   function test_NotCall_HighBidder_CancelAuctionedDebtWithSurplus(
@@ -655,7 +642,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
       0
     );
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
   function test_Call_HighBidder_CancelAuctionedDebtWithSurplus(
@@ -678,7 +665,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
       1
     );
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 
   function test_Set_Auctions_HighBidder(
@@ -688,7 +675,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
     uint256 _bidDuration,
     uint256 _totalOnAuctionDebt
   ) public happyPath(_auction, _amountToBuy, _bidDecrease, _bidDuration, _totalOnAuctionDebt) {
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
 
     assertEq(debtAuctionHouse.auctions(_auction.id).highBidder, user);
   }
@@ -700,7 +687,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
     uint256 _bidDuration,
     uint256 _totalOnAuctionDebt
   ) public happyPath(_auction, _amountToBuy, _bidDecrease, _bidDuration, _totalOnAuctionDebt) {
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
 
     assertEq(debtAuctionHouse.auctions(_auction.id).amountToSell, _amountToBuy);
   }
@@ -712,7 +699,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
     uint256 _bidDuration,
     uint256 _totalOnAuctionDebt
   ) public happyPath(_auction, _amountToBuy, _bidDecrease, _bidDuration, _totalOnAuctionDebt) {
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
 
     assertEq(debtAuctionHouse.auctions(_auction.id).bidExpiry, block.timestamp + _bidDuration);
   }
@@ -729,7 +716,7 @@ contract Unit_DebtAuctionHouse_DecreaseSoldAmount is Base {
       _auction.id, user, block.timestamp, _auction.bidAmount, _amountToBuy, block.timestamp + _bidDuration
     );
 
-    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy, _auction.bidAmount);
+    debtAuctionHouse.decreaseSoldAmount(_auction.id, _amountToBuy);
   }
 }
 

--- a/test/testnet/unit/PostSettlementSurplusAuctionHouse.t.sol
+++ b/test/testnet/unit/PostSettlementSurplusAuctionHouse.t.sol
@@ -404,7 +404,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_HighBidderNotSet.selector);
 
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Revert_BidAlreadyExpired(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
@@ -415,7 +415,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_BidAlreadyExpired.selector);
 
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Revert_AuctionAlreadyExpired(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
@@ -427,20 +427,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_AuctionAlreadyExpired.selector);
 
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
-  }
-
-  function test_Revert_AmountsNotMatching(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
-    vm.assume(_auction.highBidder != address(0));
-    vm.assume(_auction.bidExpiry == 0 || _auction.bidExpiry > block.timestamp);
-    vm.assume(_auction.auctionDeadline > block.timestamp);
-    vm.assume(_auction.amountToSell != _amountToBuy);
-
-    _mockValues(_auction, 0, 0);
-
-    vm.expectRevert(ICommonSurplusAuctionHouse.SAH_AmountsNotMatching.selector);
-
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Revert_BidNotHigher(SurplusAuction memory _auction, uint256 _bid) public {
@@ -453,7 +440,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_BidNotHigher.selector);
 
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Revert_InsufficientIncrease(SurplusAuction memory _auction, uint256 _bid, uint256 _bidIncrease) public {
@@ -469,7 +456,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_InsufficientIncrease.selector);
 
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Call_ProtocolToken_Move_0(
@@ -493,7 +480,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
     );
 
     changePrank(_auction.highBidder);
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Call_ProtocolToken_Move_1(
@@ -515,7 +502,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
       1
     );
 
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Set_Auctions_HighBidder_0(
@@ -525,7 +512,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
     changePrank(_auction.highBidder);
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(postSettlementSurplusAuctionHouse.auctions(_auction.id).highBidder, _auction.highBidder);
   }
@@ -536,7 +523,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidIncrease,
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(postSettlementSurplusAuctionHouse.auctions(_auction.id).highBidder, user);
   }
@@ -547,7 +534,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidIncrease,
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(postSettlementSurplusAuctionHouse.auctions(_auction.id).bidAmount, _bid);
   }
@@ -558,7 +545,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidIncrease,
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(postSettlementSurplusAuctionHouse.auctions(_auction.id).bidExpiry, block.timestamp + _bidDuration);
   }
@@ -574,7 +561,7 @@ contract Unit_PostSettlementSurplusAuctionHouse_IncreaseBidSize is Base {
       _auction.id, user, block.timestamp, _bid, _auction.amountToSell, block.timestamp + _bidDuration
     );
 
-    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    postSettlementSurplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 }
 

--- a/test/testnet/unit/SurplusAuctionHouse.t.sol
+++ b/test/testnet/unit/SurplusAuctionHouse.t.sol
@@ -488,25 +488,25 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
     _mockBidDuration(_bidDuration);
   }
 
-  function test_Revert_ContractIsDisabled(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_ContractIsDisabled(SurplusAuction memory _auction, uint256 _bid) public {
     _mockContractEnabled(false);
 
     vm.expectRevert(IDisableable.ContractIsDisabled.selector);
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
-  function test_Revert_HighBidderNotSet(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_HighBidderNotSet(SurplusAuction memory _auction, uint256 _bid) public {
     _auction.highBidder = address(0);
 
     _mockValues(_auction, 0, 0);
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_HighBidderNotSet.selector);
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
-  function test_Revert_BidAlreadyExpired(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_BidAlreadyExpired(SurplusAuction memory _auction, uint256 _bid) public {
     vm.assume(_auction.highBidder != address(0));
     vm.assume(_auction.bidExpiry != 0 && _auction.bidExpiry <= block.timestamp);
 
@@ -514,10 +514,10 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_BidAlreadyExpired.selector);
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
-  function test_Revert_AuctionAlreadyExpired(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
+  function test_Revert_AuctionAlreadyExpired(SurplusAuction memory _auction, uint256 _bid) public {
     vm.assume(_auction.highBidder != address(0));
     vm.assume(_auction.bidExpiry == 0 || _auction.bidExpiry > block.timestamp);
     vm.assume(_auction.auctionDeadline <= block.timestamp);
@@ -526,20 +526,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_AuctionAlreadyExpired.selector);
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
-  }
-
-  function test_Revert_AmountsNotMatching(SurplusAuction memory _auction, uint256 _amountToBuy, uint256 _bid) public {
-    vm.assume(_auction.highBidder != address(0));
-    vm.assume(_auction.bidExpiry == 0 || _auction.bidExpiry > block.timestamp);
-    vm.assume(_auction.auctionDeadline > block.timestamp);
-    vm.assume(_amountToBuy != _auction.amountToSell);
-
-    _mockValues(_auction, 0, 0);
-
-    vm.expectRevert(ICommonSurplusAuctionHouse.SAH_AmountsNotMatching.selector);
-
-    surplusAuctionHouse.increaseBidSize(_auction.id, _amountToBuy, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Revert_BidNotHigher(SurplusAuction memory _auction, uint256 _bid) public {
@@ -552,7 +539,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_BidNotHigher.selector);
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Revert_InsufficientIncrease(SurplusAuction memory _auction, uint256 _bid, uint256 _bidIncrease) public {
@@ -568,7 +555,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
 
     vm.expectRevert(ICommonSurplusAuctionHouse.SAH_InsufficientIncrease.selector);
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Call_ProtocolToken_Move_0(
@@ -591,7 +578,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
     );
 
     changePrank(_auction.highBidder);
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Call_ProtocolToken_Move_1(
@@ -611,7 +598,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
       1
     );
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 
   function test_Set_Auctions_HighBidder_0(
@@ -621,7 +608,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
     changePrank(_auction.highBidder);
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(surplusAuctionHouse.auctions(_auction.id).highBidder, _auction.highBidder);
   }
@@ -632,7 +619,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidIncrease,
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(surplusAuctionHouse.auctions(_auction.id).highBidder, user);
   }
@@ -643,7 +630,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidIncrease,
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(surplusAuctionHouse.auctions(_auction.id).bidAmount, _bid);
   }
@@ -654,7 +641,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
     uint256 _bidIncrease,
     uint256 _bidDuration
   ) public happyPath(_auction, _bid, _bidIncrease, _bidDuration) {
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
 
     assertEq(surplusAuctionHouse.auctions(_auction.id).bidExpiry, block.timestamp + _bidDuration);
   }
@@ -670,7 +657,7 @@ contract Unit_SurplusAuctionHouse_IncreaseBidSize is Base {
       _auction.id, user, block.timestamp, _bid, _auction.amountToSell, block.timestamp + _bidDuration
     );
 
-    surplusAuctionHouse.increaseBidSize(_auction.id, _auction.amountToSell, _bid);
+    surplusAuctionHouse.increaseBidSize(_auction.id, _bid);
   }
 }
 


### PR DESCRIPTION
Removed `_amountToBuy` from SAH and `_bid` from DAH