### PR TITLE
Better test support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
 		path = lib/ds-test
 		url = https://github.com/dapphub/ds-test
 [submodule "lib/forge-std"]
-		path = lib/forge-std
-		url = https://github.com/brockelmore/forge-std
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
 		branch = chore/v1.5.4
 [submodule "lib/isolmate"]
 		path = lib/isolmate

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,6 @@
 [submodule "lib/ds-test"]
 		path = lib/ds-test
 		url = https://github.com/dapphub/ds-test
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
-		branch = chore/v1.5.4
 [submodule "lib/isolmate"]
 		path = lib/isolmate
 		url = https://github.com/defi-wonderland/isolmate

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 		path = lib/prb-test
 		url = https://github.com/paulrberg/prb-test
 	    branch = 0.5.5
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/foundry.toml
+++ b/foundry.toml
@@ -32,7 +32,7 @@ out = 'out-via-ir'
 fuzz_runs = 5000
 
 [profile.test]
-via_ir = true
+via_ir = false
 out = 'out-via-ir'
 fuzz_runs = 5000
 src = 'test'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "forge build",
     "coverage": "forge coverage",
-    "deploy:anvil": "bash -c 'source .env && forge script DeployAnvil --with-gas-price 2000000000 -vvvvv --rpc-url $ANVIL_RPC --private-key $ANVIL_ONE --broadcast --ffi' && cp broadcast/Deploy.s.sol/31337/run-latest.json deployments/anvil/ && node tasks/parseAnvilDeployments.js",
+    "deploy:anvil": "bash -c 'source .env && forge script DeployAnvil --with-gas-price 2000000000 -vvvvv --rpc-url $ANVIL_RPC --private-key $ANVIL_ONE --broadcast --ffi' && mkdir -p deployments/anvil/ && cp broadcast/Deploy.s.sol/31337/run-latest.json deployments/anvil/ && node tasks/parseAnvilDeployments.js",
     "deploy:mainnet": "bash -c 'source .env && forge script DeployMainnet --rpc-url $ARB_MAINNET_RPC --broadcast --private-key $ARB_MAINNET_DEPLOYER_PK --verify --etherscan-api-key $ARB_ETHERSCAN_API_KEY'",
     "deploy:mainnet:ffi": "bash -c 'source .env && forge script DeployMainnet --rpc-url $ARB_MAINNET_RPC --broadcast --private-key $ARB_MAINNET_DEPLOYER_PK --verify --etherscan-api-key $ARB_ETHERSCAN_API_KEY --ffi'",
     "deploy:sepolia:ffi": "bash -c 'source .env && forge script DeploySepolia --with-gas-price 2000000000 -vvvvv --chain-id 461614 --rpc-url $ARB_SEPOLIA_RPC --private-key $ARB_SEPOLIA_DEPLOYER_PK --broadcast --verify --etherscan-api-key $ARB_ETHERSCAN_API_KEY --ffi'",

--- a/script/Common.s.sol
+++ b/script/Common.s.sol
@@ -31,7 +31,7 @@ abstract contract Common is Contracts, Params, Test {
   // Exclude anvil from the fork check - Not opt for overriding to avoid obscuring the logic
   // Only relevant if we start a anvil instance outside the tests .eg `forge script DeployAnvil --rpc-url $ANVIL_RPC`
   function onFork() public view returns (bool status) {
-    status = getChainId() != 31_337 && isFork();
+    status = !isNetworkAnvil() && isFork();
   }
 
   function isNetworkAnvil() public view returns (bool) {

--- a/script/Common.s.sol
+++ b/script/Common.s.sol
@@ -8,7 +8,6 @@ import {VmSafe} from 'forge-std/Script.sol';
 import {Params, ParamChecker, OD, ETH_A, JOB_REWARD} from '@script/Params.s.sol';
 
 abstract contract Common is Contracts, Params, Test {
-
   uint256 internal _chainId;
   uint256 internal _deployerPk = 69; // for tests - from OD
   uint256 internal _governorPK;
@@ -32,19 +31,19 @@ abstract contract Common is Contracts, Params, Test {
   // Exclude anvil from the fork check - Not opt for overriding to avoid obscuring the logic
   // Only relevant if we start a anvil instance outside the tests .eg `forge script DeployAnvil --rpc-url $ANVIL_RPC`
   function onFork() public view returns (bool status) {
-    status = _chainId != 31337 && isFork();
+    status = _chainId != 31_337 && isFork();
   }
 
   function isNetworkAnvil() public view returns (bool) {
-    return _chainId == 31337;
+    return _chainId == 31_337;
   }
 
   function isNetworkArbitrumSepolia() public view returns (bool) {
-    return _chainId == 421614;
+    return _chainId == 421_614;
   }
 
   function isNetworkArbitrumOne() public view returns (bool) {
-    return _chainId == 42161;
+    return _chainId == 42_161;
   }
 
   function getSemiRandSalt() public view returns (bytes32) {
@@ -418,7 +417,7 @@ abstract contract Common is Contracts, Params, Test {
 
   // @dev: only run function if on fork
   modifier runIfFork() {
-    if(onFork()) {
+    if (onFork()) {
       _;
     }
   }
@@ -426,7 +425,7 @@ abstract contract Common is Contracts, Params, Test {
   // @dev: if in the middle of a active broadcast, call function and restore original caller after execution.
   // @attention: function is responsible for starting and stopping the broadcast it needs
   modifier restoreOriginalCaller() {
-    (VmSafe.CallerMode callerMode, address activeBroadcastAddr, ) = vm.readCallers();
+    (VmSafe.CallerMode callerMode, address activeBroadcastAddr,) = vm.readCallers();
     bool activeBroadcast = callerMode == VmSafe.CallerMode.RecurrentBroadcast;
     if (activeBroadcast) {
       vm.stopBroadcast();

--- a/script/Common.s.sol
+++ b/script/Common.s.sol
@@ -16,7 +16,7 @@ abstract contract Common is Contracts, Params, Test {
   bytes internal _systemCoinInitCode;
   bytes internal _vault721InitCode;
 
-  function logGovernor() public {
+  function logGovernor() public runIfFork {
     emit log_named_address('Governor', governor);
   }
 
@@ -31,19 +31,19 @@ abstract contract Common is Contracts, Params, Test {
   // Exclude anvil from the fork check - Not opt for overriding to avoid obscuring the logic
   // Only relevant if we start a anvil instance outside the tests .eg `forge script DeployAnvil --rpc-url $ANVIL_RPC`
   function onFork() public view returns (bool status) {
-    status = _chainId != 31_337 && isFork();
+    status = getChainId() != 31_337 && isFork();
   }
 
   function isNetworkAnvil() public view returns (bool) {
-    return _chainId == 31_337;
+    return getChainId() == 31_337;
   }
 
   function isNetworkArbitrumSepolia() public view returns (bool) {
-    return _chainId == 421_614;
+    return getChainId() == 421_614;
   }
 
   function isNetworkArbitrumOne() public view returns (bool) {
-    return _chainId == 42_161;
+    return getChainId() == 42_161;
   }
 
   function getSemiRandSalt() public view returns (bytes32) {
@@ -80,66 +80,61 @@ abstract contract Common is Contracts, Params, Test {
       ICollateralAuctionHouse(collateralAuctionHouseFactory.collateralAuctionHouses(_cType));
   }
 
-  function _revokeAllTo(address _governor) internal {
-    if (!_shouldRevoke()) return;
-
+  function _updateAuthorizationForAllContracts(address removeAddress, address addAddress) internal {
     // base contracts
-    _revoke(safeEngine, _governor);
-    _revoke(liquidationEngine, _governor);
-    _revoke(accountingEngine, _governor);
-    _revoke(oracleRelayer, _governor);
+    _revoke(safeEngine, removeAddress, addAddress);
+    _revoke(liquidationEngine, removeAddress, addAddress);
+    _revoke(accountingEngine, removeAddress, addAddress);
+    _revoke(oracleRelayer, removeAddress, addAddress);
 
     // auction houses
-    _revoke(surplusAuctionHouse, _governor);
-    _revoke(debtAuctionHouse, _governor);
+    _revoke(surplusAuctionHouse, removeAddress, addAddress);
+    _revoke(debtAuctionHouse, removeAddress, addAddress);
 
     // tax
-    _revoke(taxCollector, _governor);
-    _revoke(stabilityFeeTreasury, _governor);
+    _revoke(taxCollector, removeAddress, addAddress);
+    _revoke(stabilityFeeTreasury, removeAddress, addAddress);
 
     // tokens
-    _revoke(systemCoin, _governor);
-
-    if (protocolToken.authorizedAccounts(_governor) == false) {
-      // pre-deployed protocolToken
-      _revoke(protocolToken, _governor);
-    } else {
-      protocolToken.removeAuthorization(deployer);
-    }
+    _revoke(systemCoin, removeAddress, addAddress);
+    _revoke(protocolToken, removeAddress, addAddress);
 
     // pid controller
-    _revoke(pidController, _governor);
-    _revoke(pidRateSetter, _governor);
+    _revoke(pidController, removeAddress, addAddress);
+    _revoke(pidRateSetter, removeAddress, addAddress);
 
     // token adapters
-    _revoke(coinJoin, _governor);
+    _revoke(coinJoin, removeAddress, addAddress);
 
     if (address(ethJoin) != address(0)) {
-      _revoke(ethJoin, _governor);
+      _revoke(ethJoin, removeAddress, addAddress);
     }
 
     // factories or children
-    _revoke(chainlinkRelayerFactory, _governor);
-    _revoke(denominatedOracleFactory, _governor);
-    _revoke(delayedOracleFactory, _governor);
-
-    _revoke(collateralJoinFactory, _governor);
-    _revoke(collateralAuctionHouseFactory, _governor);
+    _revoke(chainlinkRelayerFactory, removeAddress, addAddress);
+    _revoke(denominatedOracleFactory, removeAddress, addAddress);
+    _revoke(delayedOracleFactory, removeAddress, addAddress);
+    _revoke(collateralJoinFactory, removeAddress, addAddress);
+    _revoke(collateralAuctionHouseFactory, removeAddress, addAddress);
 
     // global settlement
-    _revoke(globalSettlement, _governor);
-    _revoke(postSettlementSurplusAuctionHouse, _governor);
-    _revoke(settlementSurplusAuctioneer, _governor);
+    _revoke(globalSettlement, removeAddress, addAddress);
+    _revoke(postSettlementSurplusAuctionHouse, removeAddress, addAddress);
+    _revoke(settlementSurplusAuctioneer, removeAddress, addAddress);
 
     // jobs
-    _revoke(accountingJob, _governor);
-    _revoke(liquidationJob, _governor);
-    _revoke(oracleJob, _governor);
+    _revoke(accountingJob, removeAddress, addAddress);
+    _revoke(liquidationJob, removeAddress, addAddress);
+    _revoke(oracleJob, removeAddress, addAddress);
   }
 
-  function _revoke(IAuthorizable _contract, address _target) internal {
-    _contract.addAuthorization(_target);
-    _contract.removeAuthorization(deployer);
+  function _revoke(IAuthorizable _contract, address _removeAddress, address addAddress) internal {
+    if (addAddress != address(0)) {
+      _contract.addAuthorization(addAddress);
+    }
+    if (_removeAddress == address(0)) {
+      _contract.removeAuthorization(_removeAddress);
+    }
   }
 
   function _delegateAllTo(address __delegate) internal {
@@ -198,14 +193,10 @@ abstract contract Common is Contracts, Params, Test {
     _contract.addAuthorization(_target);
   }
 
-  function _shouldRevoke() internal view returns (bool) {
-    return governor != deployer && governor != address(0);
-  }
-
   function deployTokenGovernance() public updateParams {
     // deploy Tokens
 
-    if (_chainId != 31_337) {
+    if (!isNetworkAnvil()) {
       address systemCoinAddress = create2.create2deploy(_systemCoinSalt, _systemCoinInitCode);
       systemCoin = ISystemCoin(systemCoinAddress);
     } else {
@@ -217,7 +208,7 @@ abstract contract Common is Contracts, Params, Test {
 
     address[] memory members = new address[](0);
 
-    if (_chainId == 31_337) {
+    if (isNetworkAnvil()) {
       // deploy governance contracts for anvil
       timelockController = new TimelockController(SEPOLIA_MIN_DELAY, members, members, deployer);
       odGovernor = new ODGovernor(
@@ -243,11 +234,11 @@ abstract contract Common is Contracts, Params, Test {
   function deployContracts() public updateParams {
     // deploy Base contracts
     safeEngine = new SAFEEngine(_safeEngineParams);
-
     oracleRelayer = new OracleRelayer(address(safeEngine), systemCoinOracle, _oracleRelayerParams);
 
     surplusAuctionHouse =
       new SurplusAuctionHouse(address(safeEngine), address(protocolToken), _surplusAuctionHouseParams);
+
     debtAuctionHouse = new DebtAuctionHouse(address(safeEngine), address(protocolToken), _debtAuctionHouseParams);
 
     accountingEngine = new AccountingEngine(
@@ -384,7 +375,7 @@ abstract contract Common is Contracts, Params, Test {
   }
 
   function deployProxyContracts() public updateParams {
-    if (_chainId != 31_337) {
+    if (!isNetworkAnvil()) {
       address vault721Address = create2.create2deploy(_vault721Salt, _vault721InitCode);
       vault721 = Vault721(vault721Address);
     } else {

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import '@script/Contracts.s.sol';
 import '@script/Registry.s.sol';
 import '@script/Params.s.sol';
-import {Script} from 'forge-std/Script.sol';
+import {Script, VmSafe} from 'forge-std/Script.sol';
 import {FixedPointMathLib} from '@isolmate/utils/FixedPointMathLib.sol';
 import {IERC20Metadata} from '@openzeppelin/token/ERC20/extensions/IERC20Metadata.sol';
 import {Common} from '@script/Common.s.sol';
@@ -12,9 +12,16 @@ import {SepoliaParams} from '@script/SepoliaParams.s.sol';
 import {MainnetParams} from '@script/MainnetParams.s.sol';
 
 abstract contract Deploy is Common, Script {
-  function setupEnvironment() public virtual {}
-  function setupPostEnvironment() public virtual {}
-  function mintAirdrop() public virtual {}
+
+  function _addAuthCreate2AndProtocolToken() public runIfFork restoreOriginalCaller {
+    address deployerAddr = vm.addr(_deployerPk);
+    address create2AuthAddr = create2.authorizedAccounts()[0];
+    address protocolTokenAuthAddr = protocolToken.authorizedAccounts()[0];
+    vm.broadcast(create2AuthAddr);
+    create2.addAuthorization(deployerAddr);
+    vm.broadcast(protocolTokenAuthAddr);
+    protocolToken.addAuthorization(deployerAddr);
+  }
 
   function run() public {
     deployer = vm.addr(_deployerPk);
@@ -31,23 +38,7 @@ abstract contract Deploy is Common, Script {
     inputs[1] = 'rev-parse';
     inputs[2] = 'HEAD';
 
-    _chainId = getChainId();
-
-    if (isFork()) {
-      address create2AuthAddr = create2.authorizedAccounts()[0];
-      address protocolTokenAuthAddr = protocolToken.authorizedAccounts()[0];
-      vm.stopBroadcast();
-
-      vm.startBroadcast(create2AuthAddr);
-      create2.addAuthorization(vm.addr(_deployerPk));
-      vm.stopBroadcast();
-      vm.startBroadcast(protocolTokenAuthAddr);
-      protocolToken.addAuthorization(vm.addr(_deployerPk));
-      //protocolToken.addAuthorization(address(this));
-      vm.stopBroadcast();
-
-      vm.startBroadcast(deployer);
-    }
+    _addAuthCreate2AndProtocolToken();
 
     // Deploy oracle factories used to setup the environment
     deployOracleFactories();
@@ -76,32 +67,41 @@ abstract contract Deploy is Common, Script {
     }
 
     // Mint initial ODG airdrop Anvil
-    if (_chainId == 31_337) {
+    if (isNetworkAnvil()) {
       mintAirdrop();
     }
     // Deploy contracts related to the SafeManager usecase
     deployProxyContracts();
     // Deploy and setup contracts that rely on deployed environment
     setupPostEnvironment();
-    if (_chainId == 42_161) {
+    if (isNetworkArbitrumOne()) {
       // mainnet: revoke deployer, authorize governor
       _revokeAllTo(governor);
     } else {
-      // sepolia || anvil: revoke deployer, authorize [H, P, governor]
+      // sepolia || anvil -> revoke deployer, authorize [H, P, governor]
       _delegateAllTo(H);
       _delegateAllTo(P);
       _delegateAllTo(governor);
 
-      if (!isFork()) {
-        // if not in a fork we should remove the deployer
+      if (!onFork()) {
         _revokeAllTo(deployer);
       }
     }
   }
+
+  // abstract methods to be overridden by network-specific deployments
+  function setupEnvironment() public virtual {}
+  function setupPostEnvironment() public virtual {}
+  function mintAirdrop() public virtual {}
 }
 
 contract DeployMainnet is MainnetParams, Deploy {
+
   function setUp() public virtual {
+
+    if(!isNetworkArbitrumOne())
+        revert("DeployMainnet: network is not Arbitrum One");
+
     // set create2 factory
     create2 = IODCreate2Factory(MAINNET_CREATE2FACTORY);
     protocolToken = IProtocolToken(MAINNET_PROTOCOL_TOKEN);
@@ -171,6 +171,9 @@ contract DeploySepolia is SepoliaParams, Deploy {
   IBaseOracle public chainlinkEthUSDPriceFeed;
 
   function setUp() public virtual {
+    if(!isNetworkArbitrumSepolia())
+        revert("DeploySepolia: network is not Arbitrum Sepolia");
+
     chainId = 421_614;
     // set create2 factory
     create2 = IODCreate2Factory(TEST_CREATE2FACTORY);
@@ -231,6 +234,8 @@ contract DeploySepolia is SepoliaParams, Deploy {
 
 contract DeployAnvil is SepoliaParams, Deploy {
   function setUp() public virtual {
+    if(!isNetworkAnvil())
+        revert("DeployAnvil: network is not Anvil");
     _deployerPk = uint256(vm.envBytes32('ANVIL_ONE'));
     chainId = 31_337;
   }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -25,6 +25,7 @@ abstract contract Deploy is Common, Script {
   function run() public {
     deployer = vm.addr(_deployerPk);
     vm.startBroadcast(deployer);
+
     logGovernor();
 
     // creation bytecode
@@ -38,7 +39,6 @@ abstract contract Deploy is Common, Script {
     inputs[2] = 'HEAD';
 
     _addAuthCreate2AndProtocolToken();
-
     // Deploy oracle factories used to setup the environment
     deployOracleFactories();
     // Environment may be different for each network
@@ -64,7 +64,6 @@ abstract contract Deploy is Common, Script {
       else deployCollateralContracts(_cType);
       _setupCollateral(_cType);
     }
-
     // Mint initial ODG airdrop Anvil
     if (isNetworkAnvil()) {
       mintAirdrop();
@@ -75,15 +74,16 @@ abstract contract Deploy is Common, Script {
     setupPostEnvironment();
     if (isNetworkArbitrumOne()) {
       // mainnet: revoke deployer, authorize governor
-      _revokeAllTo(governor);
+      _updateAuthorizationForAllContracts(deployer, governor);
     } else {
       // sepolia || anvil -> revoke deployer, authorize [H, P, governor]
       _delegateAllTo(H);
       _delegateAllTo(P);
-      _delegateAllTo(governor);
 
       if (!onFork()) {
-        _revokeAllTo(deployer);
+        _updateAuthorizationForAllContracts(deployer, governor);
+      } else {
+        _delegateAllTo(governor);
       }
     }
   }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -12,7 +12,6 @@ import {SepoliaParams} from '@script/SepoliaParams.s.sol';
 import {MainnetParams} from '@script/MainnetParams.s.sol';
 
 abstract contract Deploy is Common, Script {
-
   function _addAuthCreate2AndProtocolToken() public runIfFork restoreOriginalCaller {
     address deployerAddr = vm.addr(_deployerPk);
     address create2AuthAddr = create2.authorizedAccounts()[0];
@@ -96,11 +95,10 @@ abstract contract Deploy is Common, Script {
 }
 
 contract DeployMainnet is MainnetParams, Deploy {
-
   function setUp() public virtual {
-
-    if(!isNetworkArbitrumOne())
-        revert("DeployMainnet: network is not Arbitrum One");
+    if (!isNetworkArbitrumOne()) {
+      revert('DeployMainnet: network is not Arbitrum One');
+    }
 
     // set create2 factory
     create2 = IODCreate2Factory(MAINNET_CREATE2FACTORY);
@@ -171,8 +169,9 @@ contract DeploySepolia is SepoliaParams, Deploy {
   IBaseOracle public chainlinkEthUSDPriceFeed;
 
   function setUp() public virtual {
-    if(!isNetworkArbitrumSepolia())
-        revert("DeploySepolia: network is not Arbitrum Sepolia");
+    if (!isNetworkArbitrumSepolia()) {
+      revert('DeploySepolia: network is not Arbitrum Sepolia');
+    }
 
     chainId = 421_614;
     // set create2 factory
@@ -234,8 +233,9 @@ contract DeploySepolia is SepoliaParams, Deploy {
 
 contract DeployAnvil is SepoliaParams, Deploy {
   function setUp() public virtual {
-    if(!isNetworkAnvil())
-        revert("DeployAnvil: network is not Anvil");
+    if (!isNetworkAnvil()) {
+      revert('DeployAnvil: network is not Anvil');
+    }
     _deployerPk = uint256(vm.envBytes32('ANVIL_ONE'));
     chainId = 31_337;
   }


### PR DESCRIPTION
Related to #488 
This PR updates the Foundry library and adds new features for testing. 

It introduces:

`isNetworkAnvil()` to check if running on Anvil.
New modifiers: `runIfFork()` to execute functions only on forks and `restoreOriginalCaller()` to save and restore the original caller's address.
`onFork()` to differentiate Anvil instances running as forks without altering the original `isFork()` behaviour.

Also fix Anvil script, deployment and tests