### PR TITLE
Basic action exit deltaDebt fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 yarn-error.log
 node_modules
 .DS_STORE
+.nvmrc
 
 # Foundry files
 cache
@@ -20,6 +21,7 @@ lcov.info
 # Avoid ignoring gitkeep
 !/**/.gitkeep
 .vscode/
+
 
 # Docs build files
 docs/book

--- a/script/mainnet/GenerateDebt.s.sol
+++ b/script/mainnet/GenerateDebt.s.sol
@@ -9,6 +9,7 @@ import 'forge-std/console2.sol';
 // ANVIL
 // source .env && anvil --rpc-url $ARB_MAINNET_RPC
 // source .env && forge script TestGenerate --with-gas-price 2000000000 -vvvvv --rpc-url $ANVIL_RPC --unlocked
+
 contract TestGenerate is MainnetScripts {
   function run() public {
     vm.startBroadcast(USER1);

--- a/script/mainnet/GenerateDebt.s.sol
+++ b/script/mainnet/GenerateDebt.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {MainnetScripts} from '@script/mainnet/MainnetScripts.s.sol';
+import {BasicActions} from '@contracts/proxies/actions/BasicActions.sol';
+import {WSTETH, ARB, RETH} from '@script/MainnetParams.s.sol';
+import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
+import 'forge-std/console2.sol';
+// ANVIL
+// source .env && anvil --rpc-url $ARB_MAINNET_RPC
+// source .env && forge script TestGenerate --with-gas-price 2000000000 -vvvvv --rpc-url $ANVIL_RPC --unlocked
+contract TestGenerate is MainnetScripts {
+  function run() public {
+    vm.startBroadcast(USER1);
+    address proxy = address(deployOrFind(USER1));
+    basicActions = new BasicActions();
+
+    //open safe one
+    uint256 safeId = openSafe(RETH, proxy);
+    IERC20(_reth_Address).approve(proxy, type(uint256).max);
+    depositCollatAndGenDebt(RETH, safeId, 10 ether, 1000 ether, proxy);
+    // open safe 2 to get more OD
+    // uint256 safeId2 = openSafe(RETH, proxy);
+    // depositCollatAndGenDebt(RETH, safeId2, 150 ether, 200 ether, proxy);
+    uint256 balance = systemCoin.balanceOf(USER1);
+    console2.log('Ending balance: ', balance);
+    // assert(balance == 200 ether);
+
+    vm.stopBroadcast();
+  }
+}
+
+/**
+ * 0xEff45E8e2353893BD0558bD5892A42786E9142F1::modifySAFECollateralization(0x5245544800000000000000000000000000000000000000000000000000000000, SAFEHandler: [0xD79b87bc3EB61B086d647c42EA7c1d70952c0c50], SAFEHandler: [0xD79b87bc3EB61B086d647c42EA7c1d70952c0c50], SAFEHandler: [0xD79b87bc3EB61B086d647c42EA7c1d70952c0c50], 0, -199987022715481439548 [-1.999e20])
+ */

--- a/script/mainnet/MainnetScripts.s.sol
+++ b/script/mainnet/MainnetScripts.s.sol
@@ -98,7 +98,7 @@ contract MainnetScripts is MainnetDeployment, Script, Test {
     bytes memory payload = abi.encodeWithSelector(basicActions.openSAFE.selector, address(safeManager), _cType, _proxy);
     bytes memory _safeData = ODProxy(_proxy).execute(address(basicActions), payload);
     _safeId = abi.decode(_safeData, (uint256));
-    console2.log(IERC20(_reth_Address).balanceOf(USER1));
+    console2.log('RETH BALANCE USER!: ', IERC20(_reth_Address).balanceOf(USER1));
   }
 
   function depositCollatAndGenDebt(

--- a/src/contracts/proxies/actions/BasicActions.sol
+++ b/src/contracts/proxies/actions/BasicActions.sol
@@ -99,8 +99,7 @@ contract BasicActions is CommonActions, IBasicActions {
     _modifySAFECollateralization(_manager, _safeId, 0, deltaDebt, false);
 
     // Moves the COIN amount to user's address
-    // deltaDebt should always be positive, but we use SafeCast as an extra guard
-    _collectAndExitCoins(_manager, _coinJoin, _safeId, deltaDebt.toUint256());
+    _collectAndExitCoins(_manager, _coinJoin, _safeId, _deltaWad);
   }
 
   /**
@@ -170,8 +169,7 @@ contract BasicActions is CommonActions, IBasicActions {
     _modifySAFECollateralization(_manager, _safeId, _collateralAmount.toInt(), deltaDebt, false);
 
     // Exits and transfers COIN amount to the user's address
-    // deltaDebt should always be positive, but we use SafeCast as an extra guard
-    _collectAndExitCoins(_manager, _coinJoin, _safeId, deltaDebt.toUint256());
+    _collectAndExitCoins(_manager, _coinJoin, _safeId, _deltaWad);
   }
 
   /**


### PR DESCRIPTION
closes #665 

changed the _generateDebt and _lockCollateralAndGenerateDebt, to exit _deltaWad instead of _deltaDebt

[Here](https://optimistic.etherscan.io/address/0xd36b1bD5445374Ceb7Fe4148a719584234Da7Bb0#code) is the hai basic actions for reference.