### PR TITLE
Update export action

### DIFF
--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -49,7 +49,6 @@ jobs:
           export_type: '${{ matrix.export_type }}'
 
       - name: Publish
-        run: cd export/@open-dollar/${{ matrix.export_type }} && less package.json
-        # run: cd export/open-dollar-${{ matrix.export_type }} && npm publish --access public
-        # env:
-          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: cd export/@open-dollar/${{ matrix.export_type }} && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -11,6 +11,9 @@ jobs:
   generate_interfaces:
     if: github.repository == 'open-dollar/od-contracts'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        export_type: ['interfaces', 'contracts']
 
     steps:
       - uses: actions/checkout@v3
@@ -32,22 +35,20 @@ jobs:
       - name: Build project and generate out directory
         run: yarn build
 
-      - name: Add typechain to install dependencies
-        run: yarn add typechain @typechain/web3-v1 @typechain/ethers-v6
-
-      - name: Run Interface Exporter Action
-        uses: open-dollar/solidity-exporter-action@v1.0.1
-        with:
-          out_dir: "out"
-          typing_type: "ethers-v6"
-          package_name: "@opendollar/abis"
-          destination_dir: "abis-package"
-
       - name: Generate canary tag
         if: github.ref_name != 'main'
-        run: cd abis-package && yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
+        run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
+
+      - name: Export Solidity - ${{ matrix.export_type }}
+        uses: defi-wonderland/solidity-exporter-action@v1
+        with:
+          package_name: '@open-dollar'
+          out: 'out'
+          interfaces: 'src/interfaces'
+          contracts: 'src/contracts'
+          export_type: '${{ matrix.export_type }}'
 
       - name: Publish
-        run: cd abis-package && npm publish --access public
+        run: cd export/@open-dollar-${{ matrix.export_type }} && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.1
+        uses: open-dollar/solidity-exporter-action@v2.0.2
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Export Solidity - ${{ matrix.export_type }}
         uses: defi-wonderland/solidity-exporter-action@v2.0.0
         with:
-          package_name: '@open-dollar'
+          package_name: 'open-dollar'
           out: 'out'
           interfaces: 'src/interfaces'
           contracts: 'src/contracts'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: defi-wonderland/solidity-exporter-action@v2
+        uses: defi-wonderland/solidity-exporter-action@v2.0.0
         with:
           package_name: '@open-dollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.12
+        uses: open-dollar/solidity-exporter-action@v2.0.13
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.2
+        uses: open-dollar/solidity-exporter-action@v2.0.1
         with:
           package_name: '@open-dollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.9
+        uses: open-dollar/solidity-exporter-action@v2.0.11
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.8
+        uses: open-dollar/solidity-exporter-action@v2.0.9
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.6
+        uses: open-dollar/solidity-exporter-action@v2.0.7
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,12 +40,13 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.4
+        uses: open-dollar/solidity-exporter-action@v2.0.5
         with:
           package_name: '@opendollar'
           out: 'out'
           interfaces: 'src/interfaces'
           contracts: 'src/contracts'
+          libraries: 'src/libraries'
           export_type: '${{ matrix.export_type }}'
 
       - name: Publish

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.5
+        uses: open-dollar/solidity-exporter-action@v2.0.6
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,9 +40,9 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: defi-wonderland/solidity-exporter-action@v2.0.0
+        uses: open-dollar/solidity-exporter-action@v2.0.2
         with:
-          package_name: '@open-dollar/${{ matrix.export_type }}'
+          package_name: '@open-dollar'
           out: 'out'
           interfaces: 'src/interfaces'
           contracts: 'src/contracts'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.7
+        uses: open-dollar/solidity-exporter-action@v2.0.8
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -49,6 +49,6 @@ jobs:
           export_type: '${{ matrix.export_type }}'
 
       - name: Publish
-        run: cd export/@open-dollar-${{ matrix.export_type }} && npm publish --access public
+        run: cd export/open-dollar-${{ matrix.export_type }} && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.13
+        uses: open-dollar/solidity-exporter-action@v2.0.14
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Export Solidity - ${{ matrix.export_type }}
         uses: defi-wonderland/solidity-exporter-action@v2.0.0
         with:
-          package_name: 'open-dollar'
+          package_name: '@open-dollar/${{ matrix.export_type }}'
           out: 'out'
           interfaces: 'src/interfaces'
           contracts: 'src/contracts'
           export_type: '${{ matrix.export_type }}'
 
       - name: Publish
-        run: cd export/open-dollar-${{ matrix.export_type }} && less package.json
+        run: cd export/@open-dollar/${{ matrix.export_type }} && less package.json
         # run: cd export/open-dollar-${{ matrix.export_type }} && npm publish --access public
         # env:
           # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -49,6 +49,7 @@ jobs:
           export_type: '${{ matrix.export_type }}'
 
       - name: Publish
-        run: cd export/open-dollar-${{ matrix.export_type }} && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: cd export/open-dollar-${{ matrix.export_type }} && less package.json
+        # run: cd export/open-dollar-${{ matrix.export_type }} && npm publish --access public
+        # env:
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.2
+        uses: open-dollar/solidity-exporter-action@v2.0.3
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -47,8 +47,8 @@ jobs:
           interfaces: 'src/interfaces'
           contracts: 'src/contracts'
           libraries: 'src/libraries'
-          scripts: 'src/scripts'
-          tests: 'src/tests'
+          scripts: 'script'
+          tests: 'test'
 
           export_type: '${{ matrix.export_type }}'
 

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.3
+        uses: open-dollar/solidity-exporter-action@v2.0.4
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: open-dollar/solidity-exporter-action@v2.0.11
+        uses: open-dollar/solidity-exporter-action@v2.0.12
         with:
           package_name: '@opendollar'
           out: 'out'

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -47,6 +47,9 @@ jobs:
           interfaces: 'src/interfaces'
           contracts: 'src/contracts'
           libraries: 'src/libraries'
+          scripts: 'src/scripts'
+          tests: 'src/tests'
+
           export_type: '${{ matrix.export_type }}'
 
       - name: Publish

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -42,13 +42,13 @@ jobs:
       - name: Export Solidity - ${{ matrix.export_type }}
         uses: open-dollar/solidity-exporter-action@v2.0.1
         with:
-          package_name: '@open-dollar'
+          package_name: '@opendollar'
           out: 'out'
           interfaces: 'src/interfaces'
           contracts: 'src/contracts'
           export_type: '${{ matrix.export_type }}'
 
       - name: Publish
-        run: cd export/@open-dollar/${{ matrix.export_type }} && npm publish --access public
+        run: cd export/@opendollar/${{ matrix.export_type }} && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/export-abis.yml
+++ b/.github/workflows/export-abis.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
 
       - name: Export Solidity - ${{ matrix.export_type }}
-        uses: defi-wonderland/solidity-exporter-action@v1
+        uses: defi-wonderland/solidity-exporter-action@v2
         with:
           package_name: '@open-dollar'
           out: 'out'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "script:sepolia:delegate": "bash -c 'source .env && forge script SepoliaDelegate --with-gas-price 2000000000 -vvvvv --rpc-url $ARB_SEPOLIA_RPC --broadcast --private-key $GOERLI_GOVERNOR_PK --verify --etherscan-api-key $ARB_ETHERSCAN_API_KEY'",
     "simulate-deploy:mainnet:ffi": "bash -c 'source .env && forge script DeployMainnet -vv --rpc-url $ARB_MAINNET_RPC --private-key $ARB_MAINNET_DEPLOYER_PK --ffi'",
     "simulate-deploy:sepolia": "bash -c 'source .env && forge script DeploySepolia --with-gas-price 2000000000 -vvvvv --rpc-url $ARB_SEPOLIA_RPC --private-key $ARB_SEPOLIA_DEPLOYER_PK'",
-    "test": "FOUNDRY_FUZZ_RUNS=64 FOUNDRY_FUZZ_MAX_TEST_REJECTS=1200000 forge test -vvv --ffi",
+    "test": "FOUNDRY_FUZZ_RUNS=64 FOUNDRY_FUZZ_MAX_TEST_REJECTS=10000000 forge test -vvv --ffi",
     "test:coverage": "forge coverage --report lcov && lcov --ignore-errors unused --remove lcov.info 'node_modules/*' 'script/*' 'test/*' 'src/contracts/for-test/*' 'src/libraries/*' -o lcov.info.pruned && mv lcov.info.pruned lcov.info && genhtml -o coverage-report lcov.info",
     "test:e2e": "forge test --match-contract E2E -vvv --ffi",
     "test:local": "FOUNDRY_FUZZ_RUNS=32 FOUNDRY_FUZZ_MAX_TEST_REJECTS=1000000 forge test -vvv --ffi",

--- a/src/contracts/for-test/OracleForTestnet.sol
+++ b/src/contracts/for-test/OracleForTestnet.sol
@@ -4,14 +4,10 @@ pragma solidity 0.8.20;
 import {OracleForTest} from '@contracts/for-test/OracleForTest.sol';
 import {Authorizable} from '@contracts/utils/Authorizable.sol';
 import {IBaseOracle} from '@interfaces/oracles/IBaseOracle.sol';
-import {J, P} from '@script/Registry.s.sol';
 
 // solhint-disable
 contract OracleForTestnet is IBaseOracle, Authorizable, OracleForTest {
-  constructor(uint256 _price) OracleForTest(_price) Authorizable(msg.sender) {
-    _addAuthorization(J);
-    _addAuthorization(P);
-  }
+  constructor(uint256 _price) OracleForTest(_price) Authorizable(msg.sender) {}
 
   function setPriceAndValidity(uint256 _price, bool _validity) public override isAuthorized {
     super.setPriceAndValidity(_price, _validity);

--- a/src/contracts/settlement/GlobalSettlement.sol
+++ b/src/contracts/settlement/GlobalSettlement.sol
@@ -6,7 +6,7 @@ import {
   ISAFEEngine,
   ILiquidationEngine,
   IOracleRelayer
-} from '@interfaces/settlement/IGlobalSettlement.sol';
+} from '../../interfaces/settlement/IGlobalSettlement.sol';
 
 import {ICollateralAuctionHouse} from '@interfaces/ICollateralAuctionHouse.sol';
 import {IBaseOracle} from '@interfaces/oracles/IBaseOracle.sol';

--- a/src/contracts/settlement/PostSettlementSurplusAuctionHouse.sol
+++ b/src/contracts/settlement/PostSettlementSurplusAuctionHouse.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.20;
 import {
   IPostSettlementSurplusAuctionHouse,
   ICommonSurplusAuctionHouse
-} from '@interfaces/settlement/IPostSettlementSurplusAuctionHouse.sol';
+} from '../../interfaces/settlement/IPostSettlementSurplusAuctionHouse.sol';
 import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
 import {IProtocolToken} from '@interfaces/tokens/IProtocolToken.sol';
 

--- a/src/contracts/utils/CollateralJoin.sol
+++ b/src/contracts/utils/CollateralJoin.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import {ICollateralJoin} from '@interfaces/utils/ICollateralJoin.sol';
 import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
+import {IODSafeManager} from '@interfaces/proxies/IODSafeManager.sol';
 import {IERC20Metadata} from '@openzeppelin/token/ERC20/extensions/IERC20Metadata.sol';
 
 import {Authorizable} from '@contracts/utils/Authorizable.sol';
@@ -65,6 +66,10 @@ contract CollateralJoin is Disableable, ICollateralJoin {
    * @inheritdoc ICollateralJoin
    */
   function join(address _account, uint256 _wei) external whenEnabled {
+    require(
+      IODSafeManager(safeEngine.odSafeManager()).safeHandlerToSafeId(_account) != 0,
+      'CollateralJoin: Invalid SAFEHandler'
+    );
     // Effect
     uint256 _wad = _wei * 10 ** multiplier; // convert to 18 decimals [wad]
     safeEngine.modifyCollateralBalance(collateralType, _account, _wad.toInt());

--- a/src/interfaces/proxies/IODSafeManager.sol
+++ b/src/interfaces/proxies/IODSafeManager.sol
@@ -62,6 +62,9 @@ interface IODSafeManager {
   /// @notice Address of the SAFEEngine
   function safeEngine() external view returns (address _safeEngine);
 
+  /// @notice Address of the LiquidationEngine
+  function liquidationEngine() external view returns (address _liquidationEngine);
+
   /// @notice Mapping of owner and safe permissions to a caller permissions
   function safeCan(
     address _owner,

--- a/tasks/remap.js
+++ b/tasks/remap.js
@@ -1,0 +1,83 @@
+const path = require('path');
+const fse = require('fs-extra');
+
+const transformRemappings = (file, filePath) => {
+    const fileLines = file.split('\n');
+
+    // Initialize remappings array to an empty array
+    let remappings = [];
+
+    try {
+        if (fse.existsSync('remappings.txt')) {
+            // Attempt to read the remappings file
+            const remappingsContent = fse.readFileSync('remappings.txt', 'utf8');
+
+            // Parse the content and filter empty lines
+            remappings = remappingsContent
+                .split('\n')
+                .filter(Boolean)
+                .map(line => line.trim().split('='));
+        } else {
+            return '';
+        }
+    } catch (error) {
+        // Handle the error when the file does not exist or cannot be read
+        console.error('Error reading remappings file:', error);
+    }
+
+    return fileLines
+        .map(line => {
+            // Just modify imports
+            if (!line.match(/} from '/g)) return line;
+
+            const remapping = remappings.find(([find]) => line.match(find))
+
+            const modulesKey = 'node_modules/';
+
+            if (!remapping) {
+                // Transform:
+                // import '../../../node_modules/some-file.sol';
+                // into:
+                // import 'some-file.sol';
+
+                if (line.includes(modulesKey)) {
+                    line = `import '` + line.substring(line.indexOf(modulesKey) + modulesKey.length);
+                } else {
+                    return line;
+                }
+
+                return line;
+            }
+
+            // Skip remapping dependencies eg. @openzeppelin
+            // eslint-disable @typescript-eslint/no-unsafe-call
+            if (remapping && remapping[1].includes(modulesKey)) return line;
+
+            const [keep, existingPath] = line.split(`'`);
+            const fileName = existingPath.split(remapping[0])[1]
+
+            const remappingDestination = path.relative(filePath, remapping[1]);
+
+            const newPath = path.join(remappingDestination, fileName)
+
+            // path.relative assumes arguments are directories, so we must correct
+            const dds = newPath.split("../").length - 1
+            let adjustedPath = newPath
+            if (dds === 1) adjustedPath = adjustedPath.substring(1) // replace "../" with "./"
+            else if (dds > 1) adjustedPath = adjustedPath.substring(3)   // replace "../../" with "../"
+
+            line = `${keep}'${adjustedPath}';`
+            console.log(existingPath, newPath, line);
+            return line;
+        })
+        .join('\n');
+};
+
+const run = () => {
+    // const filePath = "src/contracts/LiquidationEngine.sol"
+    const filePath = "src/contracts/settlement/GlobalSettlement.sol"
+    // const filePath = "src/contracts/settlement/PostSettlementSurplusAuctionHouse.sol"
+    const fileContents = fse.readFileSync(filePath, 'utf8');
+    console.log(transformRemappings(fileContents, filePath).substring(0, 300))
+}
+run();

--- a/test/e2e/Deploy.t.sol
+++ b/test/e2e/Deploy.t.sol
@@ -171,37 +171,3 @@ contract E2EDeploymentSepoliaTest is DeploySepolia, CommonDeploymentTest {
     super.setupPostEnvironment();
   }
 }
-
-/**
- * todo: Fix this test after next Sepolia deployment
- */
-contract SepoliaDeploymentTest is SepoliaDeployment, CommonDeploymentTest {
-  function setUp() public {
-    uint256 forkId = vm.createFork(vm.rpcUrl('sepolia'));
-    vm.selectFork(forkId);
-
-    protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
-    tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
-    timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
-    odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
-    protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
-    tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
-    timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
-    odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
-
-    _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
-    chainId = 421_614;
-    _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
-    chainId = 421_614;
-
-    _systemCoinSalt = getSemiRandSalt();
-    _vault721Salt = getSemiRandSalt();
-    _systemCoinSalt = getSemiRandSalt();
-    _vault721Salt = getSemiRandSalt();
-
-    _getEnvironmentParams();
-    _getEnvironmentParams();
-
-    run();
-  }
-}

--- a/test/e2e/Deploy.t.sol
+++ b/test/e2e/Deploy.t.sol
@@ -150,35 +150,6 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
   }
 }
 
-contract E2EDeploymentSepoliaTest is DeploySepolia, CommonDeploymentTest {
-  function setUp() public override {
-    uint256 forkId = vm.createFork(vm.rpcUrl('sepolia'));
-    vm.selectFork(forkId);
-
-    create2 = IODCreate2Factory(TEST_CREATE2FACTORY);
-    protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
-
-    tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
-    timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
-    odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
-
-    _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
-    chainId = 421_614;
-
-    _systemCoinSalt = getSemiRandSalt();
-    _vault721Salt = getSemiRandSalt();
-    run();
-  }
-
-  function setupEnvironment() public override(DeploySepolia, Deploy) {
-    super.setupEnvironment();
-  }
-
-  function setupPostEnvironment() public override(DeploySepolia, Deploy) {
-    super.setupPostEnvironment();
-  }
-}
-
 contract E2EDeploymentMainnetTest is DeployMainnet, CommonDeploymentTest {
   function setUp() public override {
     uint256 forkId = vm.createFork(vm.rpcUrl('mainnet'));
@@ -204,6 +175,35 @@ contract E2EDeploymentMainnetTest is DeployMainnet, CommonDeploymentTest {
   }
 
   function setupPostEnvironment() public override(DeployMainnet, Deploy) {
+    super.setupPostEnvironment();
+  }
+}
+
+contract E2EDeploymentSepoliaTest is DeploySepolia, CommonDeploymentTest {
+  function setUp() public override {
+    uint256 forkId = vm.createFork(vm.rpcUrl('sepolia'));
+    vm.selectFork(forkId);
+
+    create2 = IODCreate2Factory(TEST_CREATE2FACTORY);
+    protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
+
+    tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
+    timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
+    odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
+
+    _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
+    chainId = 421_614;
+
+    _systemCoinSalt = getSemiRandSalt();
+    _vault721Salt = getSemiRandSalt();
+    run();
+  }
+
+  function setupEnvironment() public override(DeploySepolia, Deploy) {
+    super.setupEnvironment();
+  }
+
+  function setupPostEnvironment() public override(DeploySepolia, Deploy) {
     super.setupPostEnvironment();
   }
 }

--- a/test/e2e/Deploy.t.sol
+++ b/test/e2e/Deploy.t.sol
@@ -161,7 +161,7 @@ contract E2EDeploymentMainnetTest is DeployMainnet, CommonDeploymentTest {
     timelockController = TimelockController(payable(MAINNET_TIMELOCK_CONTROLLER));
     odGovernor = ODGovernor(payable(MAINNET_OD_GOVERNOR));
 
-    _deployerPk = uint256(vm.envBytes32('ARB_MAINNET_TEST_DEPLOYER_PK'));
+    _deployerPk = uint256(vm.envBytes32('ARB_MAINNET_DEPLOYER_PK'));
     chainId = 42_161;
 
     _systemCoinSalt = getSemiRandSalt();

--- a/test/e2e/Deploy.t.sol
+++ b/test/e2e/Deploy.t.sol
@@ -143,39 +143,6 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
   }
 }
 
-/**
- * @dev not possible to test mainnet deployment due to predeployment of protcolToken
- *  that is exclusively authorized to single wallet
- *
- * contract E2EDeploymentMainnetTest is DeployMainnet, CommonDeploymentTest {
- *   function setUp() public override {
- *     uint256 forkId = vm.createFork(vm.rpcUrl('mainnet'));
- *     vm.selectFork(forkId);
- *
- *     create2 = IODCreate2Factory(MAINNET_CREATE2FACTORY);
- *     protocolToken = IProtocolToken(MAINNET_PROTOCOL_TOKEN);
- *     tlcGov = MAINNET_TIMELOCK_CONTROLLER;
- *     timelockController = TimelockController(payable(MAINNET_TIMELOCK_CONTROLLER));
- *     odGovernor = ODGovernor(payable(MAINNET_OD_GOVERNOR));
- *
- *     _deployerPk = uint256(vm.envBytes32('ARB_MAINNET_TEST_DEPLOYER_PK'));
- *     chainId = 42_161;
- *
- *     _systemCoinSalt = getSemiRandSalt();
- *     _vault721Salt = getSemiRandSalt();
- *
- *     run();
- *   }
- *
- *   function setupEnvironment() public override(DeployMainnet, Deploy) {
- *     super.setupEnvironment();
- *   }
- *
- *   function setupPostEnvironment() public override(DeployMainnet, Deploy) {
- *     super.setupPostEnvironment();
- *   }
- * }
- */
 contract E2EDeploymentSepoliaTest is DeploySepolia, CommonDeploymentTest {
   function setUp() public override {
     uint256 forkId = vm.createFork(vm.rpcUrl('sepolia'));
@@ -208,40 +175,33 @@ contract E2EDeploymentSepoliaTest is DeploySepolia, CommonDeploymentTest {
 /**
  * todo: Fix this test after next Sepolia deployment
  */
-// contract SepoliaDeploymentTest is SepoliaDeployment, CommonDeploymentTest {
-//   function setUp() public {
-//     uint256 forkId = vm.createFork(vm.rpcUrl('sepolia'));
-//     vm.selectFork(forkId);
+contract SepoliaDeploymentTest is SepoliaDeployment, CommonDeploymentTest {
+  function setUp() public {
+    uint256 forkId = vm.createFork(vm.rpcUrl('sepolia'));
+    vm.selectFork(forkId);
 
-//     protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
-//     tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
-//     timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
-//     odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
-//     protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
-//     tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
-//     timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
-//     odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
+    protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
+    tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
+    timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
+    odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
+    protocolToken = IProtocolToken(SEPOLIA_PROTOCOL_TOKEN);
+    tlcGov = SEPOLIA_TIMELOCK_CONTROLLER;
+    timelockController = TimelockController(payable(SEPOLIA_TIMELOCK_CONTROLLER));
+    odGovernor = ODGovernor(payable(SEPOLIA_OD_GOVERNOR));
 
-//     _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
-//     chainId = 421_614;
-//     _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
-//     chainId = 421_614;
+    _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
+    chainId = 421_614;
+    _deployerPk = uint256(vm.envBytes32('ARB_SEPOLIA_DEPLOYER_PK'));
+    chainId = 421_614;
 
-//     _systemCoinSalt = getSemiRandSalt();
-//     _vault721Salt = getSemiRandSalt();
-//     _systemCoinSalt = getSemiRandSalt();
-//     _vault721Salt = getSemiRandSalt();
+    _systemCoinSalt = getSemiRandSalt();
+    _vault721Salt = getSemiRandSalt();
+    _systemCoinSalt = getSemiRandSalt();
+    _vault721Salt = getSemiRandSalt();
 
-//     _getEnvironmentParams();
-//     _getEnvironmentParams();
+    _getEnvironmentParams();
+    _getEnvironmentParams();
 
-//     run();
-//   }
-//     run();
-//   }
-
-//   // TODO: pass
-//   function test_Delegated_OP() public {
-//     assertEq(ERC20Votes(GOERLI_GOV_TOKEN).delegates(address(collateralJoin[ARB])), tlcGov);
-//   }
-// }
+    run();
+  }
+}

--- a/test/scopes/DirectUser.t.sol
+++ b/test/scopes/DirectUser.t.sol
@@ -78,6 +78,11 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
     }
 
     _collateral.approve(address(_collateralJoin), _wei);
+    vm.mockCall(
+      address(safeManager),
+      abi.encodeWithSelector(IODSafeManager.safeHandlerToSafeId.selector, _user),
+      abi.encode(uint256(1))
+    );
     ICollateralJoin(_collateralJoin).join(_user, _wei);
     vm.stopPrank();
   }

--- a/test/scopes/ProxyUser.t.sol
+++ b/test/scopes/ProxyUser.t.sol
@@ -20,6 +20,7 @@ import {
   CommonActions,
   ODProxy
 } from '@script/Contracts.s.sol';
+import {IODSafeManager} from '@interfaces/proxies/IODSafeManager.sol';
 import {SEPOLIA_WETH} from '@script/Registry.s.sol';
 import {IWeth} from '@interfaces/external/IWeth.sol';
 import {BaseUser} from '@test/scopes/BaseUser.t.sol';
@@ -67,7 +68,11 @@ abstract contract ProxyUser is BaseUser, Contracts, ScriptBase {
 
     bytes memory _callData =
       abi.encodeWithSelector(CommonActions.joinSystemCoins.selector, address(coinJoin), _user, _amount);
-
+    vm.mockCall(
+      address(safeManager),
+      abi.encodeWithSelector(IODSafeManager.safeHandlerToSafeId.selector, _user),
+      abi.encode(uint256(1))
+    );
     _proxy.execute(address(basicActions), _callData);
     vm.stopPrank();
   }

--- a/test/single/SaveSAFE.t.sol
+++ b/test/single/SaveSAFE.t.sol
@@ -128,6 +128,7 @@ contract SingleSaveSAFETest is DSTest {
   Hevm hevm;
 
   SAFEEngine safeEngine;
+
   Feed systemCoinFeed;
   OracleRelayer oracleRelayer;
   AccountingEngine accountingEngine;
@@ -255,6 +256,11 @@ contract SingleSaveSAFETest is DSTest {
     safeEngine.addAuthorization(address(collateralJoinFactory));
     collateralA = collateralJoinFactory.deployCollateralJoin('gold', address(gold));
     gold.approve(address(collateralA), type(uint256).max);
+    hevm.mockCall(
+      address(0),
+      abi.encodeWithSelector(IODSafeManager.safeHandlerToSafeId.selector, address(this)),
+      abi.encode(uint256(1))
+    );
     collateralA.join(address(this), 1000 ether);
 
     safeEngine.updateCollateralPrice('gold', ray(1 ether), ray(1 ether));

--- a/test/unit/ODGovernor.t.sol
+++ b/test/unit/ODGovernor.t.sol
@@ -99,35 +99,35 @@ contract Unit_ODGovernorTest is Base {
     assertEq(proposalState, uint256(IGovernor.ProposalState.Active));
   }
 
-  // function test_ODGovernor_Propose_and_Cancel() public {
-  //   // setup: Alice receives tokens and delegates to herself
-  //   __mintAndDelegate(alice, 100 ether);
-  //   vm.roll(100); // move to block number to 100
-  //   (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = __createProposalArgs();
-  //   vm.startPrank(alice);
-  //   bytes32 descriptionHash = keccak256(bytes(proposal_description));
-  //   uint256 propId = odGovernor.propose(targets, values, calldatas, proposal_description);
-  //   vm.roll(10); // move to block number to some point inside the voting window
+  function test_ODGovernor_Propose_and_Cancel() public {
+    // setup: Alice receives tokens and delegates to herself
+    __mintAndDelegate(alice, 100 ether);
+    vm.roll(100); // move to block number to 100
+    (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = __createProposalArgs();
+    vm.startPrank(alice);
+    bytes32 descriptionHash = keccak256(bytes(proposal_description));
+    uint256 propId = odGovernor.propose(targets, values, calldatas, proposal_description);
+    vm.roll(10); // move to block number to some point inside the voting window
 
-  //   // cancel the proposal
-  //   odGovernor.cancel(targets, values, calldatas, descriptionHash);
-  //   uint256 proposalState = uint256(odGovernor.state(propId));
-  //   assertEq(proposalState, uint256(IGovernor.ProposalState.Canceled));
-  // }
+    // cancel the proposal
+    odGovernor.cancel(targets, values, calldatas, descriptionHash);
+    uint256 proposalState = uint256(odGovernor.state(propId));
+    assertEq(proposalState, uint256(IGovernor.ProposalState.Canceled));
+  }
 
-  // function test_ODGovernor_Propose_and_CancelExtendedArguments() public {
-  //   // setup: Alice receives tokens and delegates to herself
-  //   __mintAndDelegate(alice, 100 ether);
-  //   vm.roll(100); // move to block number to 100
-  //   (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = __createProposalArgs();
-  //   vm.startPrank(alice);
-  //   uint256 propId = odGovernor.propose(targets, values, calldatas, proposal_description);
-  //   vm.roll(10); // move to block number to some point inside the voting window
+  function test_ODGovernor_Propose_and_CancelExtendedArguments() public {
+    // setup: Alice receives tokens and delegates to herself
+    __mintAndDelegate(alice, 100 ether);
+    vm.roll(100); // move to block number to 100
+    (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = __createProposalArgs();
+    vm.startPrank(alice);
+    uint256 propId = odGovernor.propose(targets, values, calldatas, proposal_description);
+    vm.roll(10); // move to block number to some point inside the voting window
 
-  //   odGovernor.cancel(targets, values, calldatas, proposal_hash);
-  //   uint256 proposalState = uint256(odGovernor.state(propId));
-  //   assertEq(proposalState, uint256(IGovernor.ProposalState.Canceled));
-  // }
+    odGovernor.cancel(targets, values, calldatas, proposal_hash);
+    uint256 proposalState = uint256(odGovernor.state(propId));
+    assertEq(proposalState, uint256(IGovernor.ProposalState.Canceled));
+  }
 
   function test_ODGovernor_Propose_and_Execute() public {
     uint256 bobBalanceBeforeExecute = token.balanceOf(bob);


### PR DESCRIPTION
- Exporter action can be added back, since it now supports node 18
- Exporter also exports contracts, to be used in other repos eg. https://github.com/open-dollar/od-seaport-zone and https://github.com/open-dollar/arbitrum-vault-saviour