### PR TITLE
CollateralJoin safe Handler check.

### DIFF
--- a/src/contracts/utils/CollateralJoin.sol
+++ b/src/contracts/utils/CollateralJoin.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import {ICollateralJoin} from '@interfaces/utils/ICollateralJoin.sol';
 import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
+import {IODSafeManager} from '@interfaces/proxies/IODSafeManager.sol';
 import {IERC20Metadata} from '@openzeppelin/token/ERC20/extensions/IERC20Metadata.sol';
 
 import {Authorizable} from '@contracts/utils/Authorizable.sol';
@@ -65,6 +66,10 @@ contract CollateralJoin is Disableable, ICollateralJoin {
    * @inheritdoc ICollateralJoin
    */
   function join(address _account, uint256 _wei) external whenEnabled {
+    require(
+      IODSafeManager(safeEngine.odSafeManager()).safeHandlerToSafeId(_account) != 0,
+      'CollateralJoin: Invalid SAFEHandler'
+    );
     // Effect
     uint256 _wad = _wei * 10 ** multiplier; // convert to 18 decimals [wad]
     safeEngine.modifyCollateralBalance(collateralType, _account, _wad.toInt());

--- a/test/scopes/DirectUser.t.sol
+++ b/test/scopes/DirectUser.t.sol
@@ -78,6 +78,11 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
     }
 
     _collateral.approve(address(_collateralJoin), _wei);
+    vm.mockCall(
+      address(safeManager),
+      abi.encodeWithSelector(IODSafeManager.safeHandlerToSafeId.selector, _user),
+      abi.encode(uint256(1))
+    );
     ICollateralJoin(_collateralJoin).join(_user, _wei);
     vm.stopPrank();
   }

--- a/test/scopes/ProxyUser.t.sol
+++ b/test/scopes/ProxyUser.t.sol
@@ -20,6 +20,7 @@ import {
   CommonActions,
   ODProxy
 } from '@script/Contracts.s.sol';
+import {IODSafeManager} from '@interfaces/proxies/IODSafeManager.sol';
 import {SEPOLIA_WETH} from '@script/Registry.s.sol';
 import {IWeth} from '@interfaces/external/IWeth.sol';
 import {BaseUser} from '@test/scopes/BaseUser.t.sol';
@@ -67,7 +68,11 @@ abstract contract ProxyUser is BaseUser, Contracts, ScriptBase {
 
     bytes memory _callData =
       abi.encodeWithSelector(CommonActions.joinSystemCoins.selector, address(coinJoin), _user, _amount);
-
+    vm.mockCall(
+      address(safeManager),
+      abi.encodeWithSelector(IODSafeManager.safeHandlerToSafeId.selector, _user),
+      abi.encode(uint256(1))
+    );
     _proxy.execute(address(basicActions), _callData);
     vm.stopPrank();
   }

--- a/test/single/SaveSAFE.t.sol
+++ b/test/single/SaveSAFE.t.sol
@@ -128,6 +128,7 @@ contract SingleSaveSAFETest is DSTest {
   Hevm hevm;
 
   SAFEEngine safeEngine;
+
   Feed systemCoinFeed;
   OracleRelayer oracleRelayer;
   AccountingEngine accountingEngine;
@@ -255,6 +256,11 @@ contract SingleSaveSAFETest is DSTest {
     safeEngine.addAuthorization(address(collateralJoinFactory));
     collateralA = collateralJoinFactory.deployCollateralJoin('gold', address(gold));
     gold.approve(address(collateralA), type(uint256).max);
+    hevm.mockCall(
+      address(0),
+      abi.encodeWithSelector(IODSafeManager.safeHandlerToSafeId.selector, address(this)),
+      abi.encode(uint256(1))
+    );
     collateralA.join(address(this), 1000 ether);
 
     safeEngine.updateCollateralPrice('gold', ray(1 ether), ray(1 ether));


### PR DESCRIPTION
closes #686
added a check in collateralJoin to ensure that collateral is only joined to a valid safeHandler address. and fixed tests accordingly, also added a test for the revert.