### PR TITLE
add allow safe call to the protectSafe function in basicActions.

### DIFF
--- a/src/contracts/proxies/actions/BasicActions.sol
+++ b/src/contracts/proxies/actions/BasicActions.sol
@@ -270,6 +270,7 @@ contract BasicActions is CommonActions, IBasicActions {
   /// @inheritdoc IBasicActions
   function protectSAFE(address _manager, uint256 _safe, address _saviour) external delegateCall {
     ODSafeManager(_manager).protectSAFE(_safe, _saviour);
+    ODSafeManager(_manager).allowSAFE(_safe, _saviour, true);
   }
 
   /// @inheritdoc IBasicActions

--- a/test/e2e/E2ESafeManager.t.sol
+++ b/test/e2e/E2ESafeManager.t.sol
@@ -72,10 +72,9 @@ abstract contract BasicActionsForE2ETests is Common {
     ODProxy(_proxy).execute(address(basicActions), payload);
   }
 
-  function protectSAFE(address _proxy, uint256 _safe, address _liquidationEngine, address _saviour) public {
-    bytes memory payload = abi.encodeWithSelector(
-      basicActions.protectSAFE.selector, address(safeManager), _safe, _liquidationEngine, _saviour
-    );
+  function protectSAFE(address _proxy, uint256 _safe, address _saviour) public {
+    bytes memory payload =
+      abi.encodeWithSelector(basicActions.protectSAFE.selector, address(safeManager), _safe, _saviour);
     ODProxy(_proxy).execute(address(basicActions), payload);
   }
 
@@ -669,9 +668,11 @@ contract E2ESafeManagerTest_ProtectSAFE is E2ESafeManagerSetUp {
   }
 
   function test_ProtectSafe() public {
-    vm.prank(aliceProxy);
-    safeManager.protectSAFE(aliceSafeId, testSaviour);
+    assertEq(liquidationEngine.safeSaviours(testSaviour), 1, 'saviour not chosen');
+    vm.prank(alice);
+    protectSAFE(aliceProxy, aliceSafeId, testSaviour);
     assertEq(liquidationEngine.chosenSAFESaviour(_cType(), aliceData.safeHandler), testSaviour);
+    assertTrue(safeManager.safeCan(aliceProxy, aliceSafeId, 0, testSaviour));
   }
 
   function test_ProtectSafe_Revert_SafeNotAllowed() public {

--- a/test/e2e/E2ESafeManager.t.sol
+++ b/test/e2e/E2ESafeManager.t.sol
@@ -682,10 +682,11 @@ contract E2ESafeManagerTest_ProtectSAFE is E2ESafeManagerSetUp {
     protectSAFE(bobProxy, aliceSafeId, testSaviour);
     assertFalse(safeManager.safeCan(bobProxy, aliceSafeId, 0, testSaviour));
   }
+
   function test_ProtectSafe_NotAllowedAfterRevert() public {
     address randomSaviour = address(1234);
-        vm.prank(alice);
-        vm.expectRevert(ILiquidationEngine.LiqEng_SaviourNotAuthorized.selector);
+    vm.prank(alice);
+    vm.expectRevert(ILiquidationEngine.LiqEng_SaviourNotAuthorized.selector);
     protectSAFE(aliceProxy, aliceSafeId, randomSaviour);
     assertFalse(safeManager.safeCan(aliceProxy, aliceSafeId, 0, randomSaviour));
   }


### PR DESCRIPTION
closes #698
added a call to allowSAFE  to basic actions  protectSafe function and added a check in the e2e tests for a successful allow.
now when a user calls protectSafe on the basic actions it will automatically allow the chosen saviour on the safeManager.