### PR TITLE
Address Library & Common Test-Setup Functions

### DIFF
--- a/script/Common.s.sol
+++ b/script/Common.s.sol
@@ -66,7 +66,6 @@ abstract contract Common is Contracts, Params, Test {
 
   function deployCollateralContracts(bytes32 _cType) public updateParams {
     // deploy CollateralJoin and CollateralAuctionHouse
-    address _delegatee = delegatee[_cType];
     if (_cType == ARB) {
       console.log('Using arb ctype, so deploying delegatable cjoin.');
       collateralJoin[_cType] = collateralJoinFactory.deployDelegatableCollateralJoin({

--- a/src/libraries/OpenDollarV1Arbitrum.sol
+++ b/src/libraries/OpenDollarV1Arbitrum.sol
@@ -43,15 +43,13 @@ import {ILiquidationJob} from '@contracts/jobs/LiquidationJob.sol';
 import {IOracleJob} from '@contracts/jobs/OracleJob.sol';
 
 // --- Proxy Contracts ---
-import {BasicActions, CommonActions} from '@contracts/proxies/actions/BasicActions.sol';
-import {DebtBidActions} from '@contracts/proxies/actions/DebtBidActions.sol';
-import {SurplusBidActions} from '@contracts/proxies/actions/SurplusBidActions.sol';
-import {CollateralBidActions} from '@contracts/proxies/actions/CollateralBidActions.sol';
+import {IBasicActions} from '@contracts/proxies/actions/BasicActions.sol';
+import {IDebtBidActions} from '@contracts/proxies/actions/DebtBidActions.sol';
+import {ISurplusBidActions} from '@contracts/proxies/actions/SurplusBidActions.sol';
+import {ICollateralBidActions} from '@contracts/proxies/actions/CollateralBidActions.sol';
 import {PostSettlementSurplusBidActions} from '@contracts/proxies/actions/PostSettlementSurplusBidActions.sol';
-import {GlobalSettlementActions} from '@contracts/proxies/actions/GlobalSettlementActions.sol';
-import {RewardedActions} from '@contracts/proxies/actions/RewardedActions.sol';
-import {GlobalSettlementActions} from '@contracts/proxies/actions/GlobalSettlementActions.sol';
-import {PostSettlementSurplusBidActions} from '@contracts/proxies/actions/PostSettlementSurplusBidActions.sol';
+import {IGlobalSettlementActions} from '@contracts/proxies/actions/GlobalSettlementActions.sol';
+import {IRewardedActions} from '@contracts/proxies/actions/RewardedActions.sol';
 import {IODSafeManager} from '@contracts/proxies/ODSafeManager.sol';
 import {IVault721} from '@contracts/proxies/Vault721.sol';
 import {NFTRenderer} from '@contracts/proxies/NFTRenderer.sol';
@@ -187,29 +185,29 @@ library OpenDollarV1Arbitrum {
   NFTRenderer internal constant NFT_RENDERER = NFTRenderer(0xFDB6935CF3A6441f83adF60CF5C9bf89A4fd7681);
 
   /// @dev Basic Actions (inherit Common Actions)
-  BasicActions internal constant BASIC_ACTIONS = BasicActions(0x688CFd8024ba60030fE4D669fd45D914A82933db);
+  IBasicActions internal constant BASIC_ACTIONS = IBasicActions(0x688CFd8024ba60030fE4D669fd45D914A82933db);
 
   /// @dev Debt Bid Actions
-  DebtBidActions internal constant DEBT_BID_ACTIONS = DebtBidActions(0x490CEDC57E1D2409F111C6a6Db75AC6A7Fc45E4a);
+  IDebtBidActions internal constant DEBT_BID_ACTIONS = IDebtBidActions(0x490CEDC57E1D2409F111C6a6Db75AC6A7Fc45E4a);
 
   /// @dev Surplus Bid Actions
-  SurplusBidActions internal constant SURPLUS_BID_ACTIONS =
-    SurplusBidActions(0x8F43FdD337C0A84f0d00C70F3c4E6A4E52A84C7E);
+  ISurplusBidActions internal constant SURPLUS_BID_ACTIONS =
+    ISurplusBidActions(0x8F43FdD337C0A84f0d00C70F3c4E6A4E52A84C7E);
 
   /// @dev Collateral Bid Actions
-  CollateralBidActions internal constant COLLATERAL_BID_ACTIONS =
-    CollateralBidActions(0xb60772EDb81a143D98c4aB0bD1C671a5E5184179);
+  ICollateralBidActions internal constant COLLATERAL_BID_ACTIONS =
+    ICollateralBidActions(0xb60772EDb81a143D98c4aB0bD1C671a5E5184179);
 
   /// @dev Post-Settlement Bid Actions for Global Shutdown Event
   PostSettlementSurplusBidActions internal constant POSTSETTLEMENT_SURPLUS_BID_ACTIONS =
     PostSettlementSurplusBidActions(0x2B7F191E4FdCf4E354f344349302BC3E98780044);
 
   /// @dev Global Settlement Actions for Global Shutdown Event
-  GlobalSettlementActions internal constant GLOBAL_SETTLEMENT_ACTIONS =
-    GlobalSettlementActions(0xBB935d412DFab5200D01B1fcaF2aa14Af5b5b2ED);
+  IGlobalSettlementActions internal constant GLOBAL_SETTLEMENT_ACTIONS =
+    IGlobalSettlementActions(0xBB935d412DFab5200D01B1fcaF2aa14Af5b5b2ED);
 
   /// @dev Rewarded Actions
-  RewardedActions internal constant REWARDED_ACTIONS = RewardedActions(0xD51fD52C5BCC150491d1e629094a3A56B7194096);
+  IRewardedActions internal constant REWARDED_ACTIONS = IRewardedActions(0xD51fD52C5BCC150491d1e629094a3A56B7194096);
 
   /// @dev Deploy Chainlink Oracles
   IChainlinkRelayerFactory internal constant CHAINLINK_RELAYER_FACTORY =

--- a/src/libraries/OpenDollarV1Arbitrum.sol
+++ b/src/libraries/OpenDollarV1Arbitrum.sol
@@ -4,54 +4,54 @@ pragma solidity >=0.7.0;
 import {IERC20Metadata} from '@openzeppelin/token/ERC20/extensions/IERC20Metadata.sol';
 
 // --- Base Contracts ---
-import {ISystemCoin} from '@contracts/tokens/SystemCoin.sol';
-import {IProtocolToken} from '@contracts/tokens/ProtocolToken.sol';
-import {ISAFEEngine} from '@contracts/SAFEEngine.sol';
-import {ITaxCollector} from '@contracts/TaxCollector.sol';
-import {IAccountingEngine} from '@contracts/AccountingEngine.sol';
-import {ILiquidationEngine} from '@contracts/LiquidationEngine.sol';
-import {ISurplusAuctionHouse} from '@contracts/SurplusAuctionHouse.sol';
-import {IDebtAuctionHouse} from '@contracts/DebtAuctionHouse.sol';
-import {ICollateralAuctionHouse} from '@contracts/CollateralAuctionHouse.sol';
-import {IStabilityFeeTreasury} from '@contracts/StabilityFeeTreasury.sol';
-import {IPIDController} from '@contracts/PIDController.sol';
-import {IPIDRateSetter} from '@contracts/PIDRateSetter.sol';
+import {ISystemCoin} from '@interfaces/tokens/ISystemCoin.sol';
+import {IProtocolToken} from '@interfaces/tokens/IProtocolToken.sol';
+import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
+import {ITaxCollector} from '@interfaces/ITaxCollector.sol';
+import {IAccountingEngine} from '@interfaces/IAccountingEngine.sol';
+import {ILiquidationEngine} from '@interfaces/ILiquidationEngine.sol';
+import {ISurplusAuctionHouse} from '@interfaces/ISurplusAuctionHouse.sol';
+import {IDebtAuctionHouse} from '@interfaces/IDebtAuctionHouse.sol';
+import {ICollateralAuctionHouse} from '@interfaces/ICollateralAuctionHouse.sol';
+import {IStabilityFeeTreasury} from '@interfaces/IStabilityFeeTreasury.sol';
+import {IPIDController} from '@interfaces/IPIDController.sol';
+import {IPIDRateSetter} from '@interfaces/IPIDRateSetter.sol';
 
 // --- Settlement ---
-import {IGlobalSettlement} from '@contracts/settlement/GlobalSettlement.sol';
-import {IPostSettlementSurplusAuctionHouse} from '@contracts/settlement/PostSettlementSurplusAuctionHouse.sol';
-import {ISettlementSurplusAuctioneer} from '@contracts/settlement/SettlementSurplusAuctioneer.sol';
+import {IGlobalSettlement} from '@interfaces/settlement/IGlobalSettlement.sol';
+import {IPostSettlementSurplusAuctionHouse} from '@interfaces/settlement/IPostSettlementSurplusAuctionHouse.sol';
+import {ISettlementSurplusAuctioneer} from '@interfaces/settlement/ISettlementSurplusAuctioneer.sol';
 
 // --- Oracles ---
-import {IOracleRelayer} from '@contracts/OracleRelayer.sol';
-import {IDelayedOracle} from '@contracts/oracles/DelayedOracle.sol';
+import {IOracleRelayer} from '@interfaces/IOracleRelayer.sol';
+import {IDelayedOracle} from '@interfaces/oracles/IDelayedOracle.sol';
 
 // --- Token adapters ---
-import {ICoinJoin} from '@contracts/utils/CoinJoin.sol';
-import {ICollateralJoin} from '@contracts/utils/CollateralJoin.sol';
+import {ICoinJoin} from '@interfaces/utils/ICoinJoin.sol';
+import {ICollateralJoin} from '@interfaces/utils/ICollateralJoin.sol';
 
 // --- Factories ---
-import {ICollateralJoinFactory} from '@contracts/factories/CollateralJoinFactory.sol';
-import {ICollateralAuctionHouseFactory} from '@contracts/factories/CollateralAuctionHouseFactory.sol';
-import {IChainlinkRelayerFactory} from '@contracts/factories/ChainlinkRelayerFactory.sol';
-import {IDenominatedOracleFactory} from '@contracts/factories/DenominatedOracleFactory.sol';
-import {IDelayedOracleFactory} from '@contracts/factories/DelayedOracleFactory.sol';
+import {ICollateralJoinFactory} from '@interfaces/factories/ICollateralJoinFactory.sol';
+import {ICollateralAuctionHouseFactory} from '@interfaces/factories/ICollateralAuctionHouseFactory.sol';
+import {IChainlinkRelayerFactory} from '@interfaces/factories/IChainlinkRelayerFactory.sol';
+import {IDenominatedOracleFactory} from '@interfaces/factories/IDenominatedOracleFactory.sol';
+import {IDelayedOracleFactory} from '@interfaces/factories/IDelayedOracleFactory.sol';
 
 // --- Jobs ---
-import {IAccountingJob} from '@contracts/jobs/AccountingJob.sol';
-import {ILiquidationJob} from '@contracts/jobs/LiquidationJob.sol';
-import {IOracleJob} from '@contracts/jobs/OracleJob.sol';
+import {IAccountingJob} from '@interfaces/jobs/IAccountingJob.sol';
+import {ILiquidationJob} from '@interfaces/jobs/ILiquidationJob.sol';
+import {IOracleJob} from '@interfaces/jobs/IOracleJob.sol';
 
 // --- Proxy Contracts ---
-import {IBasicActions} from '@contracts/proxies/actions/BasicActions.sol';
-import {IDebtBidActions} from '@contracts/proxies/actions/DebtBidActions.sol';
-import {ISurplusBidActions} from '@contracts/proxies/actions/SurplusBidActions.sol';
-import {ICollateralBidActions} from '@contracts/proxies/actions/CollateralBidActions.sol';
+import {IBasicActions} from '@interfaces/proxies/actions/IBasicActions.sol';
+import {IDebtBidActions} from '@interfaces/proxies/actions/IDebtBidActions.sol';
+import {ISurplusBidActions} from '@interfaces/proxies/actions/ISurplusBidActions.sol';
+import {ICollateralBidActions} from '@interfaces/proxies/actions/ICollateralBidActions.sol';
 import {PostSettlementSurplusBidActions} from '@contracts/proxies/actions/PostSettlementSurplusBidActions.sol';
-import {IGlobalSettlementActions} from '@contracts/proxies/actions/GlobalSettlementActions.sol';
-import {IRewardedActions} from '@contracts/proxies/actions/RewardedActions.sol';
-import {IODSafeManager} from '@contracts/proxies/ODSafeManager.sol';
-import {IVault721} from '@contracts/proxies/Vault721.sol';
+import {IGlobalSettlementActions} from '@interfaces/proxies/actions/IGlobalSettlementActions.sol';
+import {IRewardedActions} from '@interfaces/proxies/actions/IRewardedActions.sol';
+import {IODSafeManager} from '@interfaces/proxies/IODSafeManager.sol';
+import {IVault721} from '@interfaces/proxies/IVault721.sol';
 import {NFTRenderer} from '@contracts/proxies/NFTRenderer.sol';
 
 // --- Governance Contracts ---

--- a/src/libraries/OpenDollarV1Arbitrum.sol
+++ b/src/libraries/OpenDollarV1Arbitrum.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0;
+
+// --- Base Contracts ---
+import {ISystemCoin} from '@contracts/tokens/SystemCoin.sol';
+import {IProtocolToken} from '@contracts/tokens/ProtocolToken.sol';
+import {ISAFEEngine} from '@contracts/SAFEEngine.sol';
+import {ITaxCollector} from '@contracts/TaxCollector.sol';
+import {IAccountingEngine} from '@contracts/AccountingEngine.sol';
+import {ILiquidationEngine} from '@contracts/LiquidationEngine.sol';
+import {ISurplusAuctionHouse} from '@contracts/SurplusAuctionHouse.sol';
+import {IDebtAuctionHouse} from '@contracts/DebtAuctionHouse.sol';
+import {ICollateralAuctionHouse} from '@contracts/CollateralAuctionHouse.sol';
+import {IStabilityFeeTreasury} from '@contracts/StabilityFeeTreasury.sol';
+import {IPIDController} from '@contracts/PIDController.sol';
+import {IPIDRateSetter} from '@contracts/PIDRateSetter.sol';
+
+// --- Settlement ---
+import {IGlobalSettlement} from '@contracts/settlement/GlobalSettlement.sol';
+import {IPostSettlementSurplusAuctionHouse} from '@contracts/settlement/PostSettlementSurplusAuctionHouse.sol';
+import {ISettlementSurplusAuctioneer} from '@contracts/settlement/SettlementSurplusAuctioneer.sol';
+
+// --- Oracles ---
+import {IOracleRelayer} from '@contracts/OracleRelayer.sol';
+import {IDelayedOracle} from '@contracts/oracles/DelayedOracle.sol';
+
+// --- Token adapters ---
+import {ICoinJoin} from '@contracts/utils/CoinJoin.sol';
+import {ICollateralJoin} from '@contracts/utils/CollateralJoin.sol';
+
+// --- Factories ---
+import {ICollateralJoinFactory} from '@contracts/factories/CollateralJoinFactory.sol';
+import {ICollateralAuctionHouseFactory} from '@contracts/factories/CollateralAuctionHouseFactory.sol';
+import {IChainlinkRelayerFactory} from '@contracts/factories/ChainlinkRelayerFactory.sol';
+import {IDenominatedOracleFactory} from '@contracts/factories/DenominatedOracleFactory.sol';
+import {IDelayedOracleFactory} from '@contracts/factories/DelayedOracleFactory.sol';
+
+// --- Jobs ---
+import {IAccountingJob} from '@contracts/jobs/AccountingJob.sol';
+import {ILiquidationJob} from '@contracts/jobs/LiquidationJob.sol';
+import {IOracleJob} from '@contracts/jobs/OracleJob.sol';
+
+// --- Proxy Contracts ---
+import {BasicActions, CommonActions} from '@contracts/proxies/actions/BasicActions.sol';
+import {DebtBidActions} from '@contracts/proxies/actions/DebtBidActions.sol';
+import {SurplusBidActions} from '@contracts/proxies/actions/SurplusBidActions.sol';
+import {CollateralBidActions} from '@contracts/proxies/actions/CollateralBidActions.sol';
+import {PostSettlementSurplusBidActions} from '@contracts/proxies/actions/PostSettlementSurplusBidActions.sol';
+import {GlobalSettlementActions} from '@contracts/proxies/actions/GlobalSettlementActions.sol';
+import {RewardedActions} from '@contracts/proxies/actions/RewardedActions.sol';
+import {GlobalSettlementActions} from '@contracts/proxies/actions/GlobalSettlementActions.sol';
+import {PostSettlementSurplusBidActions} from '@contracts/proxies/actions/PostSettlementSurplusBidActions.sol';
+import {IODSafeManager} from '@contracts/proxies/ODSafeManager.sol';
+import {IVault721} from '@contracts/proxies/Vault721.sol';
+import {NFTRenderer} from '@contracts/proxies/NFTRenderer.sol';
+
+// --- Governance Contracts ---
+import {TimelockController} from '@openzeppelin/governance/TimelockController.sol';
+import {ODGovernor} from '@contracts/gov/ODGovernor.sol';
+
+library OpenDollarV1Arbitrum {
+  /// @dev Open Dollar Coin
+  ISystemCoin internal constant SYSTEM_COIN = ISystemCoin(0x221A0f68770658C15B525d0F89F5da2baAB5f321);
+
+  /// @dev Open Dollar Governance Token
+  IProtocolToken internal constant PROTOCOL_TOKEN = IProtocolToken(0x000D636bD52BFc1B3a699165Ef5aa340BEA8939c);
+
+  /// @dev ERC721 Non Fungible Vault
+  IVault721 internal constant VAULT721 = IVault721(0x0005AFE00fF7E7FF83667bFe4F2996720BAf0B36);
+
+  /// @dev Timelock Controller for OD Governor
+  TimelockController internal constant OD_TIMELOCK_CONTROLLER =
+    TimelockController(payable(0x7A528eA3E06D85ED1C22219471Cf0b1851943903));
+
+  /// @dev OD Governor for Open-Dollar DAO
+  ODGovernor internal constant OD_GOVERNOR = ODGovernor(payable(0xf704735CE81165261156b41D33AB18a08803B86F));
+
+  /// @dev Deploy Delayed Oracles
+  IDelayedOracleFactory internal constant DELAYED_ORACLE_FACTORY =
+    IDelayedOracleFactory(0x9Dd63fA54dEfd8820BCAb3e3cC39aeEc1aE88098);
+
+  /// @dev ARB Delayed Oracle
+  IDelayedOracle internal constant DELAYED_ORACLE_CHILD_ARB = IDelayedOracle(0xa4e0410E7eb9a02aa9C0505F629d01890c816A77);
+
+  /// @dev WSTETH Delayed Oracle
+  IDelayedOracle internal constant DELAYED_ORACLE_CHILD_WSTETH =
+    IDelayedOracle(0x026d81728a24c0F20A83c9263A455922c70b84aC);
+
+  /// @dev RETH Delayed Oracle
+  IDelayedOracle internal constant DELAYED_ORACLE_CHILD_RETH =
+    IDelayedOracle(0x9420eFb9808b0ed432Ad5AD41C302bc908FE344f);
+
+  /// @dev Safe Engine
+  ISAFEEngine internal constant SAFE_ENGINE = ISAFEEngine(0xEff45E8e2353893BD0558bD5892A42786E9142F1);
+
+  /// @dev Oracle Relayer
+  IOracleRelayer internal constant ORACLE_RELAYER = IOracleRelayer(0x7404fc1F3796748FAE17011b57Fad9713185c1d6);
+
+  /// @dev SAH
+  ISurplusAuctionHouse internal constant SURPLUS_AUCTION_HOUSE =
+    ISurplusAuctionHouse(0xA18aFB1953648ec7465d536287a015C237927369);
+
+  /// @dev DAH
+  IDebtAuctionHouse internal constant DEBT_AUCTION_HOUSE = IDebtAuctionHouse(0x5A021f2063bc2D26fd24a632e29587Afe14D30e5);
+
+  /// @dev Accounting Engine
+  IAccountingEngine internal constant ACCOUNTING_ENGINE = IAccountingEngine(0x92Bbc105430F96ddB09300A3b94cf77E3538d92c);
+
+  /// @dev Liquidation Engine
+  ILiquidationEngine internal constant LIQUIDATION_ENGINE =
+    ILiquidationEngine(0x17e546dDCE2EA8A74Bd667269457A2e80b309965);
+
+  /// @dev CAH Factory
+  ICollateralAuctionHouseFactory internal constant COLLATERAL_AUCTION_HOUSE_FACTORY =
+    ICollateralAuctionHouseFactory(0x5dc1E86361faC018f24Ae0D1E5eB01D70AB32A82);
+
+  /// @dev System Coin (OD) Join
+  ICoinJoin internal constant COIN_JOIN = ICoinJoin(0xeE4393C6165a416c83756198A56395F48bbf480f);
+
+  /// @dev Collateral Join Factory
+  ICollateralJoinFactory internal constant COLLATERAL_JOIN_FACTORY =
+    ICollateralJoinFactory(0xa83c0f1e9eD8E383919Dde0fC90744ae370EB7B3);
+
+  /// @dev Tax Collector
+  ITaxCollector internal constant TAX_COLLECTOR = ITaxCollector(0xc93F938A95488a03b976A15B20fAcFD52D087fB2);
+
+  /// @dev Stability Fee Treasury
+  IStabilityFeeTreasury internal constant STABILITY_FEE_TREASURY =
+    IStabilityFeeTreasury(0x9C86C719Aa29D426C50Ee3BAEd40008D292b02CF);
+
+  /// @dev Global Settlement for Global Shutdown Event
+  IGlobalSettlement internal constant GLOBAL_SETTLEMENT = IGlobalSettlement(0x1c6B7ab018be82ed6b5c63aE82D9f07bb7B231A2);
+
+  /// @dev Post-Settlement SAH for Global Shutdown Event
+  IPostSettlementSurplusAuctionHouse internal constant POSTSETTLEMENT_SURPLUS_AUCTION_HOUSE =
+    IPostSettlementSurplusAuctionHouse(0x9b9ae60c5475c0735125c3Fb42345AAB780a7a2c);
+
+  /// @dev Settlement Actioneer
+  ISettlementSurplusAuctioneer internal constant SETTLEMENT_SURPLUS_AUCTIONEER =
+    ISettlementSurplusAuctioneer(0x6c70B191Fc602Bd3756F0aB3684662BBfD8599A6);
+
+  /// @dev PID Controller
+  IPIDController internal constant PID_CONTROLLER = IPIDController(0x51f0434645Aa8a98cFa9f0fE7b373297a95Fe92C);
+
+  /// @dev PID Rate Setter
+  IPIDRateSetter internal constant PID_RATE_SETTER = IPIDRateSetter(0xBbb7cC351e323f069602B28B3087b5A50Eb9C654);
+
+  /// @dev Accounting Job
+  IAccountingJob internal constant ACCOUNTING_JOB = IAccountingJob(0x724f970b507F120f81130cE3924d738Db08d69f2);
+
+  /// @dev Liquidation Job
+  ILiquidationJob internal constant LIQUIDATION_JOB = ILiquidationJob(0x667F9a20d887Ff5943CCf6B35944332aDAE7E2ED);
+
+  /// @dev Oracle Job
+  IOracleJob internal constant ORACLE_JOB = IOracleJob(0xFaD87e9c629c5c8D84eDB3A134fB998AC80995Ee);
+
+  /// @dev Collateral Join for ARB
+  ICollateralJoin internal constant COLLATERAL_JOIN_CHILD_ARB =
+    ICollateralJoin(0x526Afa46F46Fd80BAa7A6CB62169e59309854611);
+
+  /// @dev CAH for ARB
+  ICollateralAuctionHouse internal constant CAH_CHILD_ARB =
+    ICollateralAuctionHouse(0x42757A0f17CbE17014f7f914c4146AC7D7f44bB4);
+
+  /// @dev Collateral Join for WSTETH
+  ICollateralJoin internal constant COLLATERAL_JOIN_CHILD_WSTETH =
+    ICollateralJoin(0xae7Df58bB63b2Db798f85AB7BCACE340d55f6f39);
+
+  /// @dev CAH for WSTETH
+  ICollateralAuctionHouse internal constant CAH_CHILD_WSTETH =
+    ICollateralAuctionHouse(0x0365dFC776851e970bd6269a2862eFc9a6265273);
+
+  /// @dev Collateral Join for RETH
+  ICollateralJoin internal constant COLLATERAL_JOIN_CHILD_RETH =
+    ICollateralJoin(0xC215F3509AFbB303Bf4a20CBFAA5382fad9bEA1D);
+
+  /// @dev CAH for RETH
+  ICollateralAuctionHouse internal constant CAH_CHILD_RETH =
+    ICollateralAuctionHouse(0x51a423B43101B219a9ECdEC67525896d856186Ec);
+
+  /// @dev Safe Mananger to interact with Safe Engine
+  IODSafeManager internal constant SAFE_MANANGER = IODSafeManager(0x8646CBd915eAAD1a4E2Ba5e2b67Acec4957d5f1a);
+
+  /// @dev Renderer of NFV SVG
+  NFTRenderer internal constant NFT_RENDERER = NFTRenderer(0xFDB6935CF3A6441f83adF60CF5C9bf89A4fd7681);
+
+  /// @dev Basic Actions (inherit Common Actions)
+  BasicActions internal constant BASIC_ACTIONS = BasicActions(0x688CFd8024ba60030fE4D669fd45D914A82933db);
+
+  /// @dev Debt Bid Actions
+  DebtBidActions internal constant DEBT_BID_ACTIONS = DebtBidActions(0x490CEDC57E1D2409F111C6a6Db75AC6A7Fc45E4a);
+
+  /// @dev Surplus Bid Actions
+  SurplusBidActions internal constant SURPLUS_BID_ACTIONS =
+    SurplusBidActions(0x8F43FdD337C0A84f0d00C70F3c4E6A4E52A84C7E);
+
+  /// @dev Collateral Bid Actions
+  CollateralBidActions internal constant COLLATERAL_BID_ACTIONS =
+    CollateralBidActions(0xb60772EDb81a143D98c4aB0bD1C671a5E5184179);
+
+  /// @dev Post-Settlement Bid Actions for Global Shutdown Event
+  PostSettlementSurplusBidActions internal constant POSTSETTLEMENT_SURPLUS_BID_ACTIONS =
+    PostSettlementSurplusBidActions(0x2B7F191E4FdCf4E354f344349302BC3E98780044);
+
+  /// @dev Global Settlement Actions for Global Shutdown Event
+  GlobalSettlementActions internal constant GLOBAL_SETTLEMENT_ACTIONS =
+    GlobalSettlementActions(0xBB935d412DFab5200D01B1fcaF2aa14Af5b5b2ED);
+
+  /// @dev Rewarded Actions
+  RewardedActions internal constant REWARDED_ACTIONS = RewardedActions(0xD51fD52C5BCC150491d1e629094a3A56B7194096);
+
+  /// @dev Deploy Chainlink Oracles
+  IChainlinkRelayerFactory internal constant CHAINLINK_RELAYER_FACTORY =
+    IChainlinkRelayerFactory(0x06C32500489C28Bd57c551afd8311Fef20bFaBB5);
+
+  /// @dev Deploy Denominated Oracles
+  IDenominatedOracleFactory internal constant DENOMINATED_ORACLE_FACTORY =
+    IDenominatedOracleFactory(0xBF760b23d2ef3615cec549F22b95a34DB0F8f5CD);
+
+  /// @dev Deploy Camelot Oracles (interface in od-relayer repo)
+  address internal constant CAMELOT_RELAYER_FACTORY = 0x36645830479170265A154Acb726780fdaE41A28F;
+}

--- a/src/libraries/OpenDollarV1Arbitrum.sol
+++ b/src/libraries/OpenDollarV1Arbitrum.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.7.0;
 
+import {IERC20Metadata} from '@openzeppelin/token/ERC20/extensions/IERC20Metadata.sol';
+
 // --- Base Contracts ---
 import {ISystemCoin} from '@contracts/tokens/SystemCoin.sol';
 import {IProtocolToken} from '@contracts/tokens/ProtocolToken.sol';
@@ -219,4 +221,10 @@ library OpenDollarV1Arbitrum {
 
   /// @dev Deploy Camelot Oracles (interface in od-relayer repo)
   address internal constant CAMELOT_RELAYER_FACTORY = 0x36645830479170265A154Acb726780fdaE41A28F;
+
+  /// @dev Collateral IERC20Metadata Tokens
+  IERC20Metadata internal constant WETH = IERC20Metadata(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+  IERC20Metadata internal constant WSTETH = IERC20Metadata(0x5979D7b546E38E414F7E9822514be443A4800529);
+  IERC20Metadata internal constant RETH = IERC20Metadata(0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8);
+  IERC20Metadata internal constant ARB = IERC20Metadata(0x912CE59144191C1204E64559FE8253a0e49E6548);
 }

--- a/test/e2e/Deploy.t.sol
+++ b/test/e2e/Deploy.t.sol
@@ -20,7 +20,7 @@ import {IProtocolToken} from '@contracts/tokens/ProtocolToken.sol';
 
 abstract contract CommonDeploymentTest is ODTest, Deploy {
   // SAFEEngine
-  function test_SAFEEngine_Auth() public {
+  function test_SAFEEngine_Auth() public view {
     assertEq(safeEngine.authorizedAccounts(address(oracleRelayer)), true);
     assertEq(safeEngine.authorizedAccounts(address(taxCollector)), true);
     assertEq(safeEngine.authorizedAccounts(address(debtAuctionHouse)), true);
@@ -34,12 +34,12 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
   }
 
   // OracleRelayer
-  function test_OracleRelayer_Auth() public {
+  function test_OracleRelayer_Auth() public view {
     assertEq(oracleRelayer.authorizedAccounts(address(pidRateSetter)), true);
   }
 
   // AccountingEngine
-  function test_AccountingEngine_Auth() public {
+  function test_AccountingEngine_Auth() public view {
     assertEq(accountingEngine.authorizedAccounts(address(liquidationEngine)), true);
   }
 
@@ -48,17 +48,17 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
   }
 
   // SystemCoin
-  function test_SystemCoin_Auth() public {
+  function test_SystemCoin_Auth() public view {
     assertEq(systemCoin.authorizedAccounts(address(coinJoin)), true);
   }
 
   // ProtocolToken
-  function test_ProtocolToken_Auth() public {
+  function test_ProtocolToken_Auth() public view {
     assertEq(protocolToken.authorizedAccounts(address(debtAuctionHouse)), true);
   }
 
   // SurplusAuctionHouse
-  function test_SurplusAuctionHouse_Auth() public {
+  function test_SurplusAuctionHouse_Auth() public view {
     assertEq(surplusAuctionHouse.authorizedAccounts(address(accountingEngine)), true);
   }
 
@@ -67,7 +67,7 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
   }
 
   // DebtAuctionHouse
-  function test_DebtAuctionHouse_Auth() public {
+  function test_DebtAuctionHouse_Auth() public view {
     assertEq(debtAuctionHouse.authorizedAccounts(address(accountingEngine)), true);
   }
 
@@ -76,7 +76,7 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
   }
 
   // CollateralAuctionHouse
-  function test_CollateralAuctionHouse_Auth() public {
+  function test_CollateralAuctionHouse_Auth() public view {
     for (uint256 _i; _i < collateralTypes.length; _i++) {
       bytes32 _cType = collateralTypes[_i];
       assertEq(collateralAuctionHouse[_cType].authorizedAccounts(address(liquidationEngine)), true);
@@ -92,7 +92,7 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
     }
   }
 
-  function test_Grant_Auth() public {
+  function test_Grant_Auth() public view {
     uint256 _id;
     assembly {
       _id := chainid()
@@ -112,7 +112,7 @@ abstract contract CommonDeploymentTest is ODTest, Deploy {
     }
   }
 
-  function _test_Authorizations(address _target, bool _permission) internal {
+  function _test_Authorizations(address _target, bool _permission) internal view {
     // base contracts
     assertEq(safeEngine.authorizedAccounts(_target), _permission);
     assertEq(oracleRelayer.authorizedAccounts(_target), _permission);

--- a/test/e2e/E2ELiquidation.t.sol
+++ b/test/e2e/E2ELiquidation.t.sol
@@ -41,8 +41,6 @@ contract E2ELiquidation is Common {
 
   IERC20 public reth;
 
-  mapping(address proxy => uint256 safeId) public vaults;
-
   function setUp() public virtual override {
     super.setUp();
     refreshCData(RETH);
@@ -205,18 +203,5 @@ contract E2ELiquidation is Common {
     oracleParams = oracleRelayer.cParams(_cType);
     liquidationCRatio = oracleParams.liquidationCRatio;
     safetyCRatio = oracleParams.safetyCRatio;
-  }
-
-  function userVaultSetup(
-    bytes32 _cType,
-    address _user,
-    uint256 _amount,
-    string memory _name
-  ) public returns (address _proxy) {
-    _proxy = deployOrFind(_user);
-    mintToken(_cType, _user, _amount, _proxy);
-    vm.label(_proxy, _name);
-    vm.prank(_proxy);
-    vaults[_proxy] = safeManager.openSAFE(_cType, _proxy);
   }
 }

--- a/test/e2e/E2ELiquidation.t.sol
+++ b/test/e2e/E2ELiquidation.t.sol
@@ -171,12 +171,7 @@ contract E2ELiquidation is Common {
     emit log_named_uint('Ali Locked   CType Bal', _a_c);
     emit log_named_uint('Ali System   Coin  Bal', systemCoin.balanceOf(alice));
     emit log_named_uint('Ali Generate Debt  Bal', _a_d);
-    // emit log_named_uint('Bob Internal cType Bal', safeEngine.tokenCollateral(RETH, bobNFV.safeHandler));
-    // (uint256 _b_c, uint256 _b_d) = getSAFE(RETH, bobNFV.safeHandler);
-    // emit log_named_uint('Bob Locked  cType  Bal', _b_c);
-    // emit log_named_uint('Bob  System  Coin  Bal', systemCoin.balanceOf(bob));
-    // emit log_named_uint('Bob Generate Debt  Bal', _b_d);
-    emit log_named_bytes32('BREAK ----------------', bytes32(0x00));
+    emit log_named_uint('----------------------', 0);
   }
 
   function getSAFE(bytes32 _cType, address _safe) public view returns (uint256 _collateral, uint256 _debt) {

--- a/test/e2e/E2ELiquidation.t.sol
+++ b/test/e2e/E2ELiquidation.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.20;
 
 import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
-import {ODProxy} from '@contracts/proxies/ODProxy.sol';
 import {IVault721} from '@interfaces/proxies/IVault721.sol';
 import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
 import {ILiquidationEngine} from '@interfaces/ILiquidationEngine.sol';
@@ -174,12 +173,6 @@ contract E2ELiquidation is Common {
     emit log_named_uint('----------------------', 0);
   }
 
-  function getSAFE(bytes32 _cType, address _safe) public view returns (uint256 _collateral, uint256 _debt) {
-    ISAFEEngine.SAFE memory _safeData = safeEngine.safes(_cType, _safe);
-    _collateral = _safeData.lockedCollateral;
-    _debt = _safeData.generatedDebt;
-  }
-
   function getRatio(bytes32 _cType, uint256 _collateral, uint256 _debt) public view returns (uint256 _ratio) {
     _ratio = _collateral.wmul(oracleRelayer.cParams(_cType).oracle.read()).wdiv(_debt.wmul(accumulatedRate));
   }
@@ -225,65 +218,5 @@ contract E2ELiquidation is Common {
     vm.label(_proxy, _name);
     vm.prank(_proxy);
     vaults[_proxy] = safeManager.openSAFE(_cType, _proxy);
-  }
-
-  function mintToken(bytes32 _cType, address _account, uint256 _amount, address _okAccount) public {
-    vm.startPrank(_account);
-    deal(address(collateral[_cType]), _account, _amount);
-    if (_okAccount != address(0)) {
-      IERC20(address(collateral[_cType])).approve(_okAccount, _amount);
-    }
-    vm.stopPrank();
-  }
-
-  function deployOrFind(address _owner) public returns (address) {
-    address proxy = vault721.getProxy(_owner);
-    if (proxy == address(0)) {
-      return address(vault721.build(_owner));
-    } else {
-      return proxy;
-    }
-  }
-
-  function depositCollateralAndGenDebt(
-    bytes32 _cType,
-    uint256 _safeId,
-    uint256 _collatAmount,
-    uint256 _deltaWad,
-    address _proxy
-  ) public {
-    vm.startPrank(ODProxy(_proxy).OWNER());
-    bytes memory _payload = abi.encodeWithSelector(
-      basicActions.lockTokenCollateralAndGenerateDebt.selector,
-      address(safeManager),
-      address(collateralJoin[_cType]),
-      address(coinJoin),
-      _safeId,
-      _collatAmount,
-      _deltaWad
-    );
-    ODProxy(_proxy).execute(address(basicActions), _payload);
-    vm.stopPrank();
-  }
-
-  function buyCollateral(
-    bytes32 _cType,
-    uint256 _auctionId,
-    uint256 _minCollateral,
-    uint256 _bid,
-    address _proxy
-  ) public {
-    vm.startPrank(ODProxy(_proxy).OWNER());
-    bytes memory _payload = abi.encodeWithSelector(
-      collateralBidActions.buyCollateral.selector,
-      address(coinJoin),
-      address(collateralJoin[_cType]),
-      address(collateralAuctionHouse[_cType]),
-      _auctionId,
-      _minCollateral,
-      _bid
-    );
-    ODProxy(_proxy).execute(address(collateralBidActions), _payload);
-    vm.stopPrank();
   }
 }

--- a/test/e2e/E2ENFT.t.sol
+++ b/test/e2e/E2ENFT.t.sol
@@ -41,15 +41,6 @@ contract NFTSetup is Common {
     debtCeiling = params.safeDebtCeiling;
   }
 
-  function deployOrFind(address owner) public returns (address) {
-    address proxy = vault721.getProxy(owner);
-    if (proxy == address(0)) {
-      return address(vault721.build(owner));
-    } else {
-      return proxy;
-    }
-  }
-
   function depositCollatAndGenDebt(
     bytes32 _cType,
     uint256 _safeId,

--- a/test/e2e/E2ESafeManager.t.sol
+++ b/test/e2e/E2ESafeManager.t.sol
@@ -161,15 +161,6 @@ abstract contract E2ESafeManagerSetUp is Base_CType, BasicActionsForE2ETests {
     _token.approve(address(aliceProxy), type(uint256).max);
   }
 
-  // function deployOrFind(address owner) public returns (address payable) {
-  //   address proxy = vault721.getProxy(owner);
-  //   if (proxy == address(0)) {
-  //     return vault721.build(owner);
-  //   } else {
-  //     return payable(address(proxy));
-  //   }
-  // }
-
   function _cType() internal pure override returns (bytes32) {
     return TKN;
   }

--- a/test/e2e/E2ESafeManager.t.sol
+++ b/test/e2e/E2ESafeManager.t.sol
@@ -161,14 +161,14 @@ abstract contract E2ESafeManagerSetUp is Base_CType, BasicActionsForE2ETests {
     _token.approve(address(aliceProxy), type(uint256).max);
   }
 
-  function deployOrFind(address owner) public returns (address payable) {
-    address proxy = vault721.getProxy(owner);
-    if (proxy == address(0)) {
-      return vault721.build(owner);
-    } else {
-      return payable(address(proxy));
-    }
-  }
+  // function deployOrFind(address owner) public returns (address payable) {
+  //   address proxy = vault721.getProxy(owner);
+  //   if (proxy == address(0)) {
+  //     return vault721.build(owner);
+  //   } else {
+  //     return payable(address(proxy));
+  //   }
+  // }
 
   function _cType() internal pure override returns (bytes32) {
     return TKN;

--- a/test/e2e/E2ESafeManager.t.sol
+++ b/test/e2e/E2ESafeManager.t.sol
@@ -456,14 +456,7 @@ contract E2ESafeManagerTest_TransferCollateral is E2ESafeManagerSetUp {
     depositCollatAndGenDebt(_cType(), aliceSafeId, _scenario.lockedCollateral, 0, aliceProxy);
     modifySAFECollateralization(aliceProxy, aliceSafeId, -int256(_scenario.lockedCollateral), 0);
     vm.stopPrank();
-    bytes memory payload = abi.encodeWithSelector(
-      basicActions.transferCollateralWithCType.selector,
-      address(safeManager),
-      _cType(),
-      aliceSafeId,
-      bob,
-      _scenario.lockedCollateral
-    );
+
     vm.prank(bob);
     vm.expectRevert(IODSafeManager.SafeNotAllowed.selector);
     safeManager.transferCollateral(_cType(), aliceSafeId, bob, _scenario.lockedCollateral);

--- a/test/e2e/E2ETest.t.sol
+++ b/test/e2e/E2ETest.t.sol
@@ -53,12 +53,7 @@ abstract contract E2ETest is BaseUser, Base_CType, Common, IERC721Receiver {
     taxCollector.taxSingle(_cType());
   }
 
-  function onERC721Received(
-    address operator,
-    address from,
-    uint256 tokenId,
-    bytes calldata data
-  ) external returns (bytes4) {
+  function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
     return IERC721Receiver.onERC721Received.selector;
   }
 

--- a/test/lib/ODLib.t.sol
+++ b/test/lib/ODLib.t.sol
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.20;
 
-import 'forge-std/Test.sol';
-import '@script/Registry.s.sol';
-import {OpenDollarV1Arbitrum} from '@libraries/OpenDollarV1Arbitrum.sol';
-import {ISystemCoin} from '@contracts/tokens/SystemCoin.sol';
-import {IProtocolToken} from '@contracts/tokens/ProtocolToken.sol';
-import {ISAFEEngine} from '@contracts/SAFEEngine.sol';
-import {IODSafeManager} from '@contracts/proxies/ODSafeManager.sol';
-import {IVault721} from '@contracts/proxies/Vault721.sol';
+import {Test} from 'forge-std/Test.sol';
+import {MAINNET_PROTOCOL_TOKEN} from '@script/Registry.s.sol';
+import {
+  OpenDollarV1Arbitrum,
+  ISystemCoin,
+  IProtocolToken,
+  ISAFEEngine,
+  IODSafeManager,
+  IVault721
+} from '@libraries/OpenDollarV1Arbitrum.sol';
 
 contract ODLib is Test {
   ISystemCoin public systemCoin;

--- a/test/lib/ODLib.t.sol
+++ b/test/lib/ODLib.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import 'forge-std/Test.sol';
+import '@script/Registry.s.sol';
+import {OpenDollarV1Arbitrum} from '@libraries/OpenDollarV1Arbitrum.sol';
+import {ISystemCoin} from '@contracts/tokens/SystemCoin.sol';
+import {IProtocolToken} from '@contracts/tokens/ProtocolToken.sol';
+import {ISAFEEngine} from '@contracts/SAFEEngine.sol';
+import {IODSafeManager} from '@contracts/proxies/ODSafeManager.sol';
+import {IVault721} from '@contracts/proxies/Vault721.sol';
+
+contract ODLib is Test {
+  ISystemCoin public systemCoin;
+  IProtocolToken public protocolToken;
+  ISAFEEngine public safeEngine;
+  IODSafeManager public safeManager;
+  IVault721 public vault721;
+
+  function setUp() public virtual {
+    systemCoin = OpenDollarV1Arbitrum.SYSTEM_COIN;
+    protocolToken = OpenDollarV1Arbitrum.PROTOCOL_TOKEN;
+    safeEngine = OpenDollarV1Arbitrum.SAFE_ENGINE;
+    safeManager = OpenDollarV1Arbitrum.SAFE_MANANGER;
+    vault721 = OpenDollarV1Arbitrum.VAULT721;
+  }
+
+  function testODLib() public {
+    assertTrue(systemCoin == ISystemCoin(0x221A0f68770658C15B525d0F89F5da2baAB5f321));
+    assertTrue(protocolToken == IProtocolToken(MAINNET_PROTOCOL_TOKEN));
+    assertTrue(safeEngine == ISAFEEngine(0xEff45E8e2353893BD0558bD5892A42786E9142F1));
+    assertTrue(safeManager == IODSafeManager(0x8646CBd915eAAD1a4E2Ba5e2b67Acec4957d5f1a));
+    assertTrue(vault721 == IVault721(0x0005AFE00fF7E7FF83667bFe4F2996720BAf0B36));
+  }
+}

--- a/test/lib/ODLib.t.sol
+++ b/test/lib/ODLib.t.sol
@@ -20,6 +20,8 @@ contract ODLib is Test {
   IVault721 public vault721;
 
   function setUp() public virtual {
+    vm.createSelectFork(vm.rpcUrl('mainnet'));
+
     systemCoin = OpenDollarV1Arbitrum.SYSTEM_COIN;
     protocolToken = OpenDollarV1Arbitrum.PROTOCOL_TOKEN;
     safeEngine = OpenDollarV1Arbitrum.SAFE_ENGINE;
@@ -27,11 +29,20 @@ contract ODLib is Test {
     vault721 = OpenDollarV1Arbitrum.VAULT721;
   }
 
-  function testODLib() public {
+  function testODLib() public view {
     assertTrue(systemCoin == ISystemCoin(0x221A0f68770658C15B525d0F89F5da2baAB5f321));
     assertTrue(protocolToken == IProtocolToken(MAINNET_PROTOCOL_TOKEN));
     assertTrue(safeEngine == ISAFEEngine(0xEff45E8e2353893BD0558bD5892A42786E9142F1));
     assertTrue(safeManager == IODSafeManager(0x8646CBd915eAAD1a4E2Ba5e2b67Acec4957d5f1a));
     assertTrue(vault721 == IVault721(0x0005AFE00fF7E7FF83667bFe4F2996720BAf0B36));
+  }
+
+  function testTotalSupply() public view {
+    assertEq(systemCoin.totalSupply(), OpenDollarV1Arbitrum.SYSTEM_COIN.totalSupply());
+  }
+
+  function testSafeManager() public {
+    assertTrue(vault721.safeManager() == safeManager);
+    assertTrue(vault721.safeManager() == OpenDollarV1Arbitrum.VAULT721.safeManager());
   }
 }

--- a/test/mocks/SafeSaviourForTest.sol
+++ b/test/mocks/SafeSaviourForTest.sol
@@ -7,10 +7,10 @@ contract SafeSaviourForForTest is ISAFESaviour {
   constructor() {}
 
   function saveSAFE(
-    address _liquidator,
-    bytes32 _cType,
-    address _safe
-  ) external returns (bool _ok, uint256 _collateralAdded, uint256 _liquidatorReward) {
+    address,
+    bytes32,
+    address
+  ) external pure returns (bool _ok, uint256 _collateralAdded, uint256 _liquidatorReward) {
     _ok = true;
     _collateralAdded = type(uint256).max;
     _liquidatorReward = type(uint256).max;

--- a/test/scopes/DirectUser.t.sol
+++ b/test/scopes/DirectUser.t.sol
@@ -118,7 +118,7 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
       abi.encode(uint256(1))
     );
     safeEngine.modifySAFECollateralization({
-      _cType: ICollateralJoin(_collateralJoin).collateralType(),
+      _cType: _cType,
       _safe: _user,
       _collateralSource: _user,
       _debtDestination: _user,
@@ -197,7 +197,7 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
     vm.stopPrank();
   }
 
-  function _settleDebtAuction(address _user, uint256 _auctionId) internal override {
+  function _settleDebtAuction(address, uint256 _auctionId) internal override {
     debtAuctionHouse.settleAuction(_auctionId);
   }
 
@@ -223,7 +223,7 @@ abstract contract DirectUser is BaseUser, Contracts, ScriptBase {
     vm.stopPrank();
   }
 
-  function _settlePostSettlementSurplusAuction(address _user, uint256 _auctionId) internal override {
+  function _settlePostSettlementSurplusAuction(address, uint256 _auctionId) internal override {
     postSettlementSurplusAuctionHouse.settleAuction(_auctionId);
   }
 

--- a/test/scopes/ProxyUser.t.sol
+++ b/test/scopes/ProxyUser.t.sol
@@ -361,7 +361,7 @@ abstract contract ProxyUser is BaseUser, Contracts, ScriptBase {
   function _redeemCollateral(
     address _user,
     bytes32 _cType,
-    uint256 _coinsAmount
+    uint256
   ) internal override returns (uint256 _collateralAmount) {
     ODProxy _proxy = _getProxy(_user);
 


### PR DESCRIPTION
closes #729 
closes #732 
closes #738 

- added protocol address library to make contract instances easily accessible with `@opendollar` import
- added common test-setup functions in the common.t.sol file to reduce redundancy in test setups across repos